### PR TITLE
Adding channel interface to tracers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     app_utils.default_log_setup(args.log_level)
     pipeline, train_dataset, device = get_modules_from_config(args)
     optim_cls, optim_params = get_optimizer_from_config(args)
-    trainer = globals()[args.trainer](pipeline, train_dataset, args.epochs, args.batch_size,
+    trainer = globals()[args.trainer_type](pipeline, train_dataset, args.epochs, args.batch_size,
                                       optim_cls, args.lr, args.weight_decay,
                                       args.grid_lr_weight, optim_params, args.log_dir, device,
                                       exp_name=args.exp_name, info=args_str, extra_args=vars(args),

--- a/app/main_interactive.py
+++ b/app/main_interactive.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     optim_cls, optim_params = get_optimizer_from_config(args)
 
     scene_state = WispState()
-    trainer = globals()[args.trainer](pipeline, train_dataset, args.epochs, args.batch_size,
+    trainer = globals()[args.trainer_type](pipeline, train_dataset, args.epochs, args.batch_size,
                                       optim_cls, args.lr, args.weight_decay,
                                       args.grid_lr_weight, optim_params, args.log_dir, device,
                                       exp_name=args.exp_name, info=args_str, extra_args=vars(args),

--- a/ci/gitlab_jenkins_templates/ubuntu_test_CI.jenkins
+++ b/ci/gitlab_jenkins_templates/ubuntu_test_CI.jenkins
@@ -125,7 +125,7 @@ spec:
             stage("NGP-NeRF") {
               sh '''
               cd /wisp
-              python app/main.py --config configs/ngp_nerf.yaml --dataset-path /data/V8
+              python app/main.py --config configs/ngp_nerf.yaml --dataset-path /data/fox --valid-every -1
               '''
             }
         }

--- a/configs/nglod_nerf.yaml
+++ b/configs/nglod_nerf.yaml
@@ -15,7 +15,7 @@ global:
     exp_name: 'test-nglod-nerf'
 
 optimizer:
-    optimizer: 'rmsprop'
+    optimizer_type: 'rmsprop'
     lr: 0.001
 
 dataset:
@@ -26,7 +26,7 @@ dataset:
     bg_color: 'white'
 
 renderer:
-    tracer: 'PackedRFTracer'
+    tracer_type: 'PackedRFTracer'
     num_steps: 16
     render_batch: 4000
     camera_origin:
@@ -39,7 +39,7 @@ renderer:
         - 1024
 
 trainer:
-    trainer: 'MultiviewTrainer'
+    trainer_type: 'MultiviewTrainer'
     epochs: 50
     batch_size: 1
     model_format: 'full'
@@ -57,7 +57,7 @@ grid:
     num_lods: 4
 
 net:
-    nef: 'NeuralRadianceField'
+    nef_type: 'NeuralRadianceField'
     hidden_dim: 128
     num_layers: 1
     out_dim: 4

--- a/configs/nglod_nerf_ray.yaml
+++ b/configs/nglod_nerf_ray.yaml
@@ -15,7 +15,7 @@ global:
     exp_name: 'test-nglod-nerf-ray'
 
 optimizer:
-    optimizer: 'rmsprop'
+    optimizer_type: 'rmsprop'
     lr: 0.001
 
 dataset:
@@ -26,7 +26,7 @@ dataset:
     bg_color: 'white'
 
 renderer:
-    tracer: 'PackedRFTracer'
+    tracer_type: 'PackedRFTracer'
     num_steps: 512
     raymarch_type: 'ray'
     render_batch: 4000
@@ -40,7 +40,7 @@ renderer:
         - 1024
 
 trainer:
-    trainer: 'MultiviewTrainer'
+    trainer_type: 'MultiviewTrainer'
     epochs: 50
     batch_size: 1
     model_format: 'full'
@@ -58,7 +58,7 @@ grid:
     num_lods: 4
 
 net:
-    nef: 'NeuralRadianceField'
+    nef_type: 'NeuralRadianceField'
     hidden_dim: 128
     num_layers: 1
     out_dim: 4

--- a/configs/nglod_sdf.yaml
+++ b/configs/nglod_sdf.yaml
@@ -20,7 +20,7 @@ global:
     exp_name: 'test-nglod-sdf'
 
 optimizer:
-    optimizer: 'adam'
+    optimizer_type: 'adam'
     lr: 0.001
     grid_lr_weight: 1.0
 
@@ -30,7 +30,7 @@ dataset:
     dataset_type: 'sdf'
 
 renderer:
-    tracer: 'PackedSDFTracer'
+    tracer_type: 'PackedSDFTracer'
     num_steps: 128
     render_batch: 0
     step_size: 0.8
@@ -45,7 +45,7 @@ renderer:
     shadow: True
 
 trainer:
-    trainer: 'SDFTrainer'
+    trainer_type: 'SDFTrainer'
     epochs: 10
     batch_size: 512
     model_format: 'full'
@@ -66,7 +66,7 @@ grid:
     num_lods: 6
 
 net:
-    nef: 'NeuralSDF'
+    nef_type: 'NeuralSDF'
     hidden_dim: 128
     num_layers: 1
     out_dim: 1

--- a/configs/ngp_nerf.yaml
+++ b/configs/ngp_nerf.yaml
@@ -15,7 +15,7 @@ global:
     exp_name: 'test-ngp-nerf'
 
 optimizer:
-    optimizer: 'rmsprop'
+    optimizer_type: 'rmsprop'
     lr: 0.001
 
 dataset:
@@ -26,7 +26,7 @@ dataset:
     bg_color: 'white'
 
 renderer:
-    tracer: 'PackedRFTracer'
+    tracer_type: 'PackedRFTracer'
     num_steps: 512
     raymarch_type: ray
     render_batch: 4000
@@ -40,7 +40,7 @@ renderer:
         - 1024
 
 trainer:
-    trainer: 'MultiviewTrainer'
+    trainer_type: 'MultiviewTrainer'
     epochs: 50
     batch_size: 1
     model_format: 'full'
@@ -60,7 +60,7 @@ grid:
     codebook_bitwidth: 19
 
 net:
-    nef: 'NeuralRadianceField'
+    nef_type: 'NeuralRadianceField'
     hidden_dim: 128
     num_layers: 1
     out_dim: 4

--- a/configs/triplanar_nerf.yaml
+++ b/configs/triplanar_nerf.yaml
@@ -14,7 +14,7 @@ global:
     exp_name: 'test-triplanar-nerf'
 
 optimizer:
-    optimizer: 'rmsprop'
+    optimizer_type: 'rmsprop'
     lr: 0.001
 
 dataset:
@@ -25,7 +25,7 @@ dataset:
     bg_color: 'white'
 
 renderer:
-    tracer: 'PackedRFTracer'
+    tracer_type: 'PackedRFTracer'
     num_steps: 256
     render_batch: 4000
     camera_origin:
@@ -38,7 +38,7 @@ renderer:
         - 1024
 
 trainer:
-    trainer: 'MultiviewTrainer'
+    trainer_type: 'MultiviewTrainer'
     epochs: 50
     batch_size: 1
     model_format: 'full'
@@ -56,7 +56,7 @@ grid:
     num_lods: 4
 
 net:
-    nef: 'NeuralRadianceField'
+    nef_type: 'NeuralRadianceField'
     hidden_dim: 128
     num_layers: 1
     out_dim: 4

--- a/configs/triplanar_sdf.yaml
+++ b/configs/triplanar_sdf.yaml
@@ -20,7 +20,7 @@ global:
     exp_name: 'test-triplanar-sdf'
 
 optimizer:
-    optimizer: 'adam'
+    optimizer_type: 'adam'
     lr: 0.001
     grid_lr_weight: 1.0
 
@@ -29,7 +29,7 @@ dataset:
     dataset_type: 'sdf'
 
 renderer:
-    tracer: 'PackedSDFTracer'
+    tracer_type: 'PackedSDFTracer'
     num_steps: 256
     render_batch: 0
     step_size: 0.8
@@ -44,7 +44,7 @@ renderer:
     shadow: True
 
 trainer:
-    trainer: 'SDFTrainer'
+    trainer_type: 'SDFTrainer'
     epochs: 10
     batch_size: 512
     model_format: 'full'
@@ -64,7 +64,7 @@ grid:
     base_lod: 5
 
 net:
-    nef: 'NeuralSDF'
+    nef_type: 'NeuralSDF'
     hidden_dim: 128
     num_layers: 1
     out_dim: 1

--- a/configs/vqad_nerf.yaml
+++ b/configs/vqad_nerf.yaml
@@ -15,7 +15,7 @@ global:
     exp_name: 'test-vqad-nerf'
 
 optimizer:
-    optimizer: 'rmsprop'
+    optimizer_type: 'rmsprop'
     lr: 0.001
 
 dataset:
@@ -26,7 +26,7 @@ dataset:
     bg_color: 'white'
 
 renderer:
-    tracer: 'PackedRFTracer'
+    tracer_type: 'PackedRFTracer'
     num_steps: 16
     render_batch: 4000
     camera_origin:
@@ -39,7 +39,7 @@ renderer:
         - 1024
 
 trainer:
-    trainer: 'MultiviewTrainer'
+    trainer_type: 'MultiviewTrainer'
     epochs: 50
     batch_size: 1
     model_format: 'full'
@@ -58,7 +58,7 @@ grid:
     codebook_bitwidth: 4
 
 net:
-    nef: 'NeuralRadianceField'
+    nef_type: 'NeuralRadianceField'
     hidden_dim: 128
     num_layers: 1
     out_dim: 4

--- a/wisp/config_parser.py
+++ b/wisp/config_parser.py
@@ -40,7 +40,7 @@ def parse_options(return_parser=False):
     # Global arguments
     ###################
     global_group = parser.add_argument_group('global')
-    global_group.add_argument('--trainer', type=str,
+    global_group.add_argument('--trainer-type', type=str,
                               help='Trainer class to use')
     global_group.add_argument('--exp-name', type=str,
                               help='Experiment name.')
@@ -110,7 +110,7 @@ def parse_options(return_parser=False):
     ###################
     net_group = parser.add_argument_group('net')
     
-    net_group.add_argument('--nef', type=str, default='OverfitSDF', 
+    net_group.add_argument('--nef-type', type=str,
                           help='The neural field class to be used.')
     net_group.add_argument('--layer-type', type=str, default='none',
                             choices=['none', 'spectral_norm', 'frobenius_norm', 'l_1_norm', 'l_inf_norm'])
@@ -178,7 +178,7 @@ def parse_options(return_parser=False):
     # Arguments for optimizer
     ###################
     optim_group = parser.add_argument_group('optimizer')
-    optim_group.add_argument('--optimizer', type=str, default='adam', choices=list(str2optim.keys()), 
+    optim_group.add_argument('--optimizer-type', type=str, default='adam', choices=list(str2optim.keys()), 
                              help='Optimizer to be used.')
     optim_group.add_argument('--lr', type=float, default=0.001, 
                              help='Learning rate.')
@@ -262,7 +262,7 @@ def parse_options(return_parser=False):
                                 help='Camera projection.')
     renderer_group.add_argument('--camera-clamp', nargs=2, type=float, default=[0, 10], 
                                 help='Camera clipping bounds.')
-    renderer_group.add_argument('--tracer', type=str, default='PackedRFTracer', 
+    renderer_group.add_argument('--tracer-type', type=str, default='PackedRFTracer', 
                                 help='The tracer to be used.')
     
     # TODO(ttakikawa): In the future the interface will be such that you either select an absolute step size or 
@@ -376,10 +376,10 @@ def argparse_to_str(parser, args=None):
 def get_optimizer_from_config(args):
     """Utility function to get the optimizer from the parsed config.
     """
-    optim_cls = str2optim[args.optimizer]
-    if args.optimizer == 'adam':
+    optim_cls = str2optim[args.optimizer_type]
+    if args.optimizer_type == 'adam':
         optim_params = {'eps': 1e-15}
-    elif args.optimizer == 'sgd':
+    elif args.optimizer_type == 'sgd':
         optim_params = {'momentum': 0.8}
     else:
         optim_params = {}
@@ -389,8 +389,9 @@ def get_modules_from_config(args):
     """Utility function to get the modules for training from the parsed config.
     """
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-    nef = globals()[args.nef](**vars(args))
-    tracer = globals()[args.tracer](**vars(args))
+    nef = globals()[args.nef_type](**vars(args))
+    tracer = globals()[args.tracer_type]()
+    tracer.set_defaults(**vars(args))
     pipeline = Pipeline(nef, tracer)
 
     if args.pretrained:

--- a/wisp/offline_renderer.py
+++ b/wisp/offline_renderer.py
@@ -118,6 +118,8 @@ class OfflineRenderer():
         
         self.width, self.height = self.render_res
 
+        self.kwargs = kwargs
+
     def render_lookat(self, 
             pipeline, 
             f            = [0,0,1], 
@@ -180,9 +182,9 @@ class OfflineRenderer():
             if self.render_batch > 0:
                 rb = RenderBuffer(xyz=None, hit=None, normal=None, shadow=None, ao=None, dirs=None)
                 for ray_pack in rays.split(self.render_batch):
-                    rb  += pipeline.tracer(pipeline.nef, ray_pack, lod_idx=lod_idx)
+                    rb  += pipeline.tracer(pipeline.nef, rays=ray_pack, lod_idx=lod_idx, **self.kwargs)
             else:
-                rb = pipeline.tracer(pipeline.nef, rays, lod_idx=lod_idx)
+                rb = pipeline.tracer(pipeline.nef, rays=rays, lod_idx=lod_idx, **self.kwargs)
 
         ######################
         # Shading Rendering

--- a/wisp/ops/shaders/shadow_rays.py
+++ b/wisp/ops/shaders/shadow_rays.py
@@ -57,7 +57,7 @@ def pointlight_shadow_shader(rb: RenderBuffer, rays: Rays, pipeline,
         light_hit = ((shadow_ray_d * rb.normal).sum(-1) > 0.0)
 
         shadow_rays = Rays(origins=shadow_ray_o, dirs=shadow_ray_d, dist_min=0, dist_max=rays.dist_max)
-        rb.shadow = pipeline.tracer(pipeline.nef, shadow_rays).hit
+        rb.shadow = pipeline.tracer(pipeline.nef, rays=shadow_rays).hit
 
         # rb.shadow[~plane_hit] = 0.0
         rb.shadow[~light_hit] = 0.0

--- a/wisp/renderer/core/renderers/sdf_pipeline_renderer.py
+++ b/wisp/renderer/core/renderers/sdf_pipeline_renderer.py
@@ -35,8 +35,7 @@ class NeuralSDFPackedRenderer(RayTracedRenderer):
         if raymarch_type is None:
             raymarch_type = 'voxel'
 
-        self.tracer = PackedSDFTracer(num_steps=self.samples_per_ray, min_dis=min_distance,
-                                       raymarch_type=raymarch_type, bg_color='black')
+        self.tracer = PackedSDFTracer()
         self.render_res_x = None
         self.render_res_y = None
         self.output_width = None
@@ -67,7 +66,7 @@ class NeuralSDFPackedRenderer(RayTracedRenderer):
         return self._last_state.get('num_steps', 0) < self.samples_per_ray
 
     def render(self, rays: Optional[Rays] = None) -> RenderBuffer:
-        rb = self.tracer(self.nef, rays)
+        rb = self.tracer(self.nef, rays=rays)
 
         # Rescale renderbuffer to original size
         rb = rb.reshape(self.render_res_y, self.render_res_x, -1)

--- a/wisp/renderer/gui/imgui/widget_radiance_pipeline_renderer.py
+++ b/wisp/renderer/gui/imgui/widget_radiance_pipeline_renderer.py
@@ -59,7 +59,7 @@ class WidgetNeuralRadianceFieldRenderer(WidgetImgui):
                 # TODO (operel): Update the ## ids below with a unique object name to avoid imgui bug
                 def _num_samples_property():
                     max_value = MAX_SAMPLES
-                    if renderer.tracer.raymarch_type == 'ray':
+                    if renderer.raymarch_type == 'ray':
                         max_value = MAX_SAMPLES_RAY_MODE
                     value = min(renderer.num_steps, max_value)
                     changed, value = imgui.core.slider_int(f"##samples_per_ray", value=value,
@@ -69,7 +69,7 @@ class WidgetNeuralRadianceFieldRenderer(WidgetImgui):
                 
                 def _num_samples_movement_property():
                     max_value = MAX_SAMPLES
-                    if renderer.tracer.raymarch_type == 'ray':
+                    if renderer.raymarch_type == 'ray':
                         max_value = MAX_SAMPLES_RAY_MODE
                     value = min(renderer.num_steps_movement, max_value)
                     changed, value = imgui.core.slider_int(f"##samples_per_ray_movement", value=value,
@@ -84,14 +84,14 @@ class WidgetNeuralRadianceFieldRenderer(WidgetImgui):
                         renderer.batch_size = value
 
                 def _marcher_type_property():
-                    selected_marcher_idx = self.marcher_types.index(renderer.tracer.raymarch_type)
+                    selected_marcher_idx = self.marcher_types.index(renderer.raymarch_type)
                     changed, selected_marcher_idx = imgui.combo("##marcher_type",
                                                                 selected_marcher_idx, self.marcher_types)
                     if changed:
                         new_marcher_mode = self.marcher_types[selected_marcher_idx]
                         if new_marcher_mode != 'ray':
-                            renderer.tracer.num_steps = min(MAX_SAMPLES, renderer.tracer.num_steps)
-                        renderer.tracer.raymarch_type = new_marcher_mode
+                            renderer.num_steps = min(MAX_SAMPLES, renderer.num_steps)
+                        renderer.raymarch_type = new_marcher_mode
 
                 properties = {
                     "Ray Samples (static)": _num_samples_property,              # Samples per ray

--- a/wisp/tracers/base_tracer.py
+++ b/wisp/tracers/base_tracer.py
@@ -7,30 +7,120 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 import numpy as np
+import torch.nn as nn
+from abc import abstractmethod, ABC
+import inspect
 
-class BaseTracer(object):
+class BaseTracer(nn.Module, ABC):
     """Virtual base class for tracer"""
-
-    def __init__(self,
-        step_size     : float = 1.0,
-        num_steps     : int   = 64, # samples for raymaching, iterations for sphere trace
-        min_dis       : float = 1e-3,
-        bg_color      : str   = 'white',
-        raymarch_type : str   = 'voxel',
-        **kwargs): 
-
-        self.step_size = step_size
-        self.num_steps = num_steps
-        self.min_dis = min_dis
-        self.bg_color = bg_color
-        self.raymarch_type = raymarch_type
-
-        self.inv_num_steps = 1.0 / self.num_steps
-        self.diagonal = np.sqrt(3) * 2.0
+    output_channels = None
+    input_channels = None
     
-    def __call__(self, *args, **kwargs):
-        return self.forward(*args, **kwargs)
+    def __init__(self):
+        """Initializes the class.
+        """
+        super().__init__()
 
-    def forward(self, *args, **kwargs):
-        """Base implementation for forward"""
-        raise NotImplementedError
+    def set_defaults(self):
+        """Sets the default arguments for trace. 
+
+        This should be overrided and called if you want to pass custom defaults into the renderer.
+        If overrided, it should keep the arguments to `self.trace` in `self.` class variables.
+        Then, if these variables exist and no function arguments are passed into forward,
+        it will override them as the default.
+
+        TODO(ttakikawa): This is hacky.
+        """
+        pass
+
+    @abstractmethod
+    def get_output_channels(self):
+        """Returns the output channels that are supported by this class.
+
+        Implement the function to return the supported channels, e.g.       
+        return set(["depth", "rgb"])
+
+        Returns:
+            (set): Set of channel strings.
+        """
+        pass
+
+    @abstractmethod
+    def get_input_channels(self):
+        """Returns the input channels that are supported by this class.
+        
+        Implement the function to return the supported channels, e.g.       
+        return set(["rgb", "density"])
+
+        Returns:
+            (set): Set of channel strings.
+        """
+        pass
+
+
+    @abstractmethod
+    def trace(self, nef, channels, *args, **kwargs):
+        """Apply the forward map on the nef. 
+
+        This is the function to implement to implement a custom
+        This can take any number of arguments, but `nef` always needs to be the first argument and 
+        `channels` needs to be the second argument.
+        
+        Args:
+            nef (nn.Module): A neural field that uses a grid class.
+            channels (set): The set of requested channels. The trace method can return channels that 
+                            were not requested since those channels often had to be computed anyways.
+
+        Returns:
+            (wisp.RenderBuffer): A dataclass which holds the output buffers from the tracer.
+        """
+        pass
+
+    def forward(self, nef, channels=None, **kwargs):
+        """Queries the tracer with channels.
+
+        Args:
+            channels (str or list of str or set of str): Requested channels. See return value for details.
+            kwargs: Any keyword argument passed in will be passed into the respective forward functions.
+
+        Returns:
+            (wisp.RenderBuffer): A dataclass which holds the output buffers from the tracer.
+        """
+        nef_channels = nef.get_supported_channels()
+        unsupported_inputs = self.get_input_channels() - nef_channels
+        if unsupported_inputs:
+            raise Exception(f"The neural field class {type(nef)} does not support the required channels {unsupported_inputs}.")
+        
+        if channels is None:
+            requested_channels = self.get_output_channels()
+        elif isinstance(channels, str):
+            requested_channels = set([channels])
+        else:
+            requested_channels = set(channels)
+        unsupported_outputs = requested_channels - self.get_output_channels()
+        if unsupported_outputs:
+            raise Exception(f"Channels {unsupported_outputs} are not supported in {type(self)}")
+
+        argspec = inspect.getfullargspec(self.trace)
+
+        # Skip first element (self), second element (nef) and third element (channel)
+        required_args = argspec.args[:-len(argspec.defaults)][3:] 
+        optional_args = argspec.args[-len(argspec.defaults):]
+        
+        input_args = {}
+        for _arg in required_args:
+            # TODO(ttakiakwa): This doesn't actually format the string, fix :) 
+            if _arg not in kwargs:
+                raise Exception(f"Argument {_arg} not found as input to in {type(self)}.trace()")
+            input_args[_arg] = kwargs[_arg]
+        for _arg in optional_args:
+            if _arg in kwargs:
+                # By default, the function args will take priority
+                input_args[_arg] = kwargs[_arg]
+            else:
+                # Check if default_args are set, and use them if they are.
+                default_arg = getattr(self, _arg, None)
+                if default_arg is not None:
+                    input_args[_arg] = default_arg
+
+        return self.trace(nef, requested_channels, **input_args)

--- a/wisp/trainers/multiview_trainer.py
+++ b/wisp/trainers/multiview_trainer.py
@@ -70,7 +70,7 @@ class MultiviewTrainer(BaseTrainer):
             lod_idx = None
 
         with torch.cuda.amp.autocast():
-            rb = self.pipeline(rays, lod_idx=lod_idx)
+            rb = self.pipeline(rays=rays, lod_idx=lod_idx, channels=["rgb"])
             timer.check("inference")
 
             # RGB Loss


### PR DESCRIPTION
This change adds:

1. Some of the arguments have been renamed. This prevents namespace overlap and also variable name conflicts.
2. The tracer now takes channels as input, similarly to how the neural field does.
3. The tracer base class has been slightly cleaned up, with a new `set_defaults` method to enforce initial conditions if required (i.e. syncing with the renderer). This will likely be replaced by a state object in the future.

Signed-off-by: Towaki Takikawa <tovacinni@gmail.com>