### PR TITLE
Deactivate interactive mode when using the gui

### DIFF
--- a/wisp/renderer/app/wisp_app.py
+++ b/wisp/renderer/app/wisp_app.py
@@ -440,7 +440,7 @@ class WispApp(ABC):
         self.user_mode.handle_timer_tick(dt)
 
         # Toggle interactive mode on or off if needed to maintain interactive FPS rate
-        if self.user_mode.is_interacting() or self._is_imgui_hovered:
+        if self.user_mode.is_interacting():
             self.render_core.set_low_resolution()
         else:
             # Allow a fraction of a second before turning full resolution on.


### PR DESCRIPTION
A little bug fix for disabling interactive mode when the cursor hovers over the gui

Signed-off-by: operel <operel@nvidia.com>