### PR TITLE
Add Weights & Biases logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _*/
 *.egg-info
 build
 imgui.ini
+wandb/

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python3 app/main.py --config configs/nglod_nerf.yaml --dataset-path /path/to/V8 
 Take a look at `wisp/config_parser.py` for the list of different options you can pass in, and `configs/nglod_nerf.yaml` 
 for the options that are already passed in.
 
-### Logging to [Weights & Biases](https://wandb.ai/site)
+### Experiment Tracking with [Weights & Biases](https://wandb.ai/site)
 
 To track training and validation metrics, render 3D interactive plots, reproduce your configurations and results, and many more features in your Weights & Biases workspace just add the additional flag `--wandb_project <your-project-name>` when initializing the training script.
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Complete list of features supported by Weights & Biases:
 - Log interactive 360 degree renderings post training in all levels of detail.
 - Log model checkpoints as [Weights & Biases artifacts](https://wandb.ai/site/artifacts).
 - Sync experiment configs for reproducibility.
+- Host Tensorboard instance inside Weights & Biases run.
 
 The full list of optional arguments related to logging on Weights & Biases include:
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,27 @@ python3 app/main.py --config configs/nglod_nerf.yaml --dataset-path /path/to/V8 
 Take a look at `wisp/config_parser.py` for the list of different options you can pass in, and `configs/nglod_nerf.yaml` 
 for the options that are already passed in.
 
+### Logging to [Weights & Biases](https://wandb.ai/site)
+
+To track training and validation metrics, render 3D interactive plots, reproduce your configurations and results, and many more features in your Weights & Biases workspace just add the additional flag `--wandb_project <your-project-name>` when initializing the training script.
+
+Complete list of features supported by Weights & Biases:
+
+- Log training and validation metrics in real time.
+- Log system metrics in real time.
+- Log RGB, RGBA, Depth renderings etc. during training.
+- Log interactive 360 degree renderings post training in all levels of detail.
+- Log model checkpoints as [Weights & Biases artifacts](https://wandb.ai/site/artifacts).
+- Sync experiment configs for reproducibility.
+
+The full list of optional arguments related to logging on Weights & Biases include:
+
+- `--wandb_project`: Name of Weights & Biases project
+- `--wandb_run_name`: Name of Weights & Biases run \[Optional\]
+- `--wandb_entity`: Name of Weights & Biases entity under which your project resides \[Optional\]
+- `--wandb_viz_nerf_angles`: Number of angles in the 360 degree renderings \[Optional, default set to 20\]
+- `--wandb_viz_nerf_distance`: Camera distance to visualize Scene from for 360 degree renderings on Weights & Biases \[Optional, default set to 3\]
+
 ### Interactive training
 
 To run the training task interactively using the renderer engine, run:

--- a/app/main.py
+++ b/app/main.py
@@ -15,11 +15,13 @@ if __name__ == "__main__":
         get_optimizer_from_config
     from wisp.framework import WispState
     
+    import os
     import wandb
 
     # Usual boilerplate
     parser = parse_options(return_parser=True)
     parser.add_argument("--wandb_project", type=str, default=None, help="Weights & Biases Project")
+    parser.add_argument("--wandb_run_name", type=str, default=None, help="Weights & Biases Run Name")
     parser.add_argument("--wandb_entity", type=str, default=None, help="Weights & Biases Entity")
     parser.add_argument(
         "--wandb_viz_nerf_angles",
@@ -42,12 +44,13 @@ if __name__ == "__main__":
     if using_wandb:
         wandb.init(
             project=args.wandb_project,
-            name=args.exp_name,
+            name=args.exp_name if args.wandb_run_name is None else args.wandb_run_name,
             entity=args.wandb_entity,
             job_type="validate" if args.valid_only else "train",
             config=vars(args),
             sync_tensorboard=True
         )
+        scene_file = os.path.join(args.dataset_path, "scene.ply")
     
     app_utils.default_log_setup(args.log_level)
     pipeline, train_dataset, device = get_modules_from_config(args)

--- a/app/main.py
+++ b/app/main.py
@@ -14,13 +14,41 @@ if __name__ == "__main__":
     from wisp.config_parser import parse_options, argparse_to_str, get_modules_from_config, \
         get_optimizer_from_config
     from wisp.framework import WispState
+    
+    import wandb
 
     # Usual boilerplate
     parser = parse_options(return_parser=True)
+    parser.add_argument("--wandb_project", type=str, default=None, help="Weights & Biases Project")
+    parser.add_argument("--wandb_entity", type=str, default=None, help="Weights & Biases Entity")
+    parser.add_argument(
+        "--wandb_viz_nerf_angles",
+        type=int,
+        default=20,
+        help="Number of Angles to visualize Scene from on Weights & Biases"
+    )
+    parser.add_argument(
+        "--wandb_viz_nerf_distance",
+        type=int,
+        default=3,
+        help="Distance to visualize Scene from on Weights & Biases"
+    )
     app_utils.add_log_level_flag(parser)
     app_group = parser.add_argument_group('app')
     # Add custom args if needed for app
     args, args_str = argparse_to_str(parser)
+    
+    using_wandb = args.wandb_project is not None and args.wandb_entity is not None
+    if using_wandb:
+        wandb.init(
+            project=args.wandb_project,
+            name=args.exp_name,
+            entity=args.wandb_entity,
+            job_type="validate" if args.valid_only else "train",
+            config=vars(args),
+            sync_tensorboard=True
+        )
+    
     app_utils.default_log_setup(args.log_level)
     pipeline, train_dataset, device = get_modules_from_config(args)
     optim_cls, optim_params = get_optimizer_from_config(args)
@@ -28,8 +56,21 @@ if __name__ == "__main__":
                                       optim_cls, args.lr, args.weight_decay,
                                       args.grid_lr_weight, optim_params, args.log_dir, device,
                                       exp_name=args.exp_name, info=args_str, extra_args=vars(args),
-                                      render_every=args.render_every, save_every=args.save_every)
+                                      render_every=args.render_every, save_every=args.save_every, using_wandb=using_wandb)
     if args.valid_only:
         trainer.validate()
+        if using_wandb:
+            trainer.render_final_view(
+                num_angles=args.wandb_viz_nerf_angles,
+                camera_distance=args.wandb_viz_nerf_distance
+            )
     else:
         trainer.train()
+        if using_wandb:
+            trainer.render_final_view(
+                num_angles=args.wandb_viz_nerf_angles,
+                camera_distance=args.wandb_viz_nerf_distance
+            )
+    
+    if using_wandb:
+        wandb.finish()

--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         "--wandb_viz_nerf_angles",
         type=int,
         default=20,
-        help="Number of Angles to visualize Scene from on Weights & Biases"
+        help="Number of Angles to visualize a scene on Weights & Biases. Set this to 0 to disable 360 degree visualizations."
     )
     parser.add_argument(
         "--wandb_viz_nerf_distance",
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     # Add custom args if needed for app
     args, args_str = argparse_to_str(parser)
     
-    using_wandb = args.wandb_project is not None and args.wandb_entity is not None
+    using_wandb = args.wandb_project is not None
     if using_wandb:
         wandb.init(
             project=args.wandb_project,
@@ -50,7 +50,6 @@ if __name__ == "__main__":
             config=vars(args),
             sync_tensorboard=True
         )
-        scene_file = os.path.join(args.dataset_path, "scene.ply")
     
     app_utils.default_log_setup(args.log_level)
     pipeline, train_dataset, device = get_modules_from_config(args)
@@ -62,18 +61,14 @@ if __name__ == "__main__":
                                       render_every=args.render_every, save_every=args.save_every, using_wandb=using_wandb)
     if args.valid_only:
         trainer.validate()
-        if using_wandb:
-            trainer.render_final_view(
-                num_angles=args.wandb_viz_nerf_angles,
-                camera_distance=args.wandb_viz_nerf_distance
-            )
     else:
         trainer.train()
-        if using_wandb:
-            trainer.render_final_view(
-                num_angles=args.wandb_viz_nerf_angles,
-                camera_distance=args.wandb_viz_nerf_distance
-            )
+    
+    if args.trainer_type == "MultiviewTrainer" and using_wandb and args.wandb_viz_nerf_angles != 0:
+        trainer.render_final_view(
+            num_angles=args.wandb_viz_nerf_angles,
+            camera_distance=args.wandb_viz_nerf_distance
+        )
     
     if using_wandb:
         wandb.finish()

--- a/app/main_interactive.py
+++ b/app/main_interactive.py
@@ -18,6 +18,7 @@ if __name__ == "__main__":
     from wisp.config_parser import parse_options, argparse_to_str, get_modules_from_config, \
         get_optimizer_from_config
     from wisp.framework import WispState
+import wandb
 
     # Usual boilerplate
     parser = parse_options(return_parser=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Pillow
 scipy==1.5.2
 scikit-image
 scikit-learn
-six==1.12.0
+six>=1.12.0
 moviepy
 opencv-python
 plyfile
@@ -27,3 +27,4 @@ fastparquet
 PyDispatcher
 pynvml
 setuptools==59.5.0
+wandb>=13.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ fastparquet
 PyDispatcher
 pynvml
 setuptools==59.5.0
-wandb>=13.5
+wandb>=0.13.5

--- a/wisp/trainers/__init__.py
+++ b/wisp/trainers/__init__.py
@@ -6,6 +6,6 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
-from .base_trainer import BaseTrainer
+from .base_trainer import BaseTrainer, log_metric_to_wandb, log_images_to_wandb
 from .multiview_trainer import MultiviewTrainer
 from .sdf_trainer import SDFTrainer

--- a/wisp/trainers/multiview_trainer.py
+++ b/wisp/trainers/multiview_trainer.py
@@ -193,7 +193,7 @@ class MultiviewTrainer(BaseTrainer):
         rgb_gif = out_rgb[0]
         gif_path = os.path.join(self.log_dir, "rgb.gif")
         rgb_gif.save(gif_path, save_all=True, append_images=out_rgb[1:], optimize=False, loop=0)
-        wandb.log({"360-Degree-Scene/RGB-Rendering": wandb.Video(gif_path)})        
+        wandb.log({"360-Degree-Scene/RGB-Rendering": wandb.Video(gif_path)})
 
     def validate(self, epoch=0):
         self.pipeline.eval()

--- a/wisp/trainers/sdf_trainer.py
+++ b/wisp/trainers/sdf_trainer.py
@@ -23,6 +23,8 @@ from wisp.datasets import SDFDataset
 from wisp.ops.sdf import compute_sdf_iou
 from wisp.ops.image import hwc_to_chw
 
+import wandb
+
 
 class SDFTrainer(BaseTrainer):
 
@@ -104,10 +106,15 @@ class SDFTrainer(BaseTrainer):
 
         self.writer.add_scalar('Loss/l2_loss', self.log_dict['l2_loss'], epoch)
         self.writer.add_scalar('Loss/rgb_loss', self.log_dict['rgb_loss'], epoch)
+        if self.using_wandb:
+            wandb.log({"Loss/l2_loss": self.log_dict['l2_loss']}, step=epoch, commit=False)
+            wandb.log({"Loss/rgb_loss": self.log_dict['rgb_loss']}, step=epoch, commit=False)
         log.info(log_text)
 
         # Log losses
         self.writer.add_scalar('Loss/total_loss', self.log_dict['total_loss'], epoch)
+        if self.using_wandb:
+            wandb.log({"Loss/total_loss": self.log_dict['total_loss']}, step=epoch, commit=False)
 
     def render_tb(self, epoch):
         super().render_tb(epoch)
@@ -121,6 +128,16 @@ class SDFTrainer(BaseTrainer):
                 self.writer.add_image(f'Cross-section/X/{d}', hwc_to_chw(out_x), epoch)
                 self.writer.add_image(f'Cross-section/Y/{d}', hwc_to_chw(out_y), epoch)
                 self.writer.add_image(f'Cross-section/Z/{d}', hwc_to_chw(out_z), epoch)
+                if self.using_wandb:
+                    wandb.log({
+                        f'Cross-section/X/{d}': wandb.Image(np.moveaxis(hwc_to_chw(out_x), 0, -1))
+                    }, step=epoch, commit=False)
+                    wandb.log({
+                        f'Cross-section/Y/{d}': wandb.Image(np.moveaxis(hwc_to_chw(out_x), 0, -1))
+                    }, step=epoch, commit=False)
+                    wandb.log({
+                        f'Cross-section/Z/{d}': wandb.Image(np.moveaxis(hwc_to_chw(out_x), 0, -1))
+                    }, step=epoch, commit=False)
 
     def validate(self, epoch=0):
         """Implement validation. Just computes IOU.


### PR DESCRIPTION
This PR adds support for experiment tracking using [Weights & Biases](https://wandb.ai/site). In order to track training and validation metrics, render 3D interactive plots, reproduce the configurations and results, and many more features in a Weights & Biases workspace just add the additional flag `--wandb_project <your-project-name>` when initializing the training script.

Complete list of features supported by Weights & Biases:

- Log training and validation metrics in real-time.
- Log system metrics in real-time.
- Log RGB, RGBA, Depth renderings, etc. during training.
- Log interactive 360-degree renderings post-training in all levels of detail.
- Log model checkpoints as [Weights & Biases artifacts](https://wandb.ai/site/artifacts).
- Sync experiment configs for reproducibility.
- Host Tensorboard instance inside Weights & Biases run.

The full list of optional arguments related to logging on Weights & Biases includes:

- `--wandb_project`: Name of Weights & Biases project
- `--wandb_run_name`: Name of Weights & Biases run [Optional]
- `--wandb_entity`: Name of Weights & Biases entity under which your project resides [Optional]
- `--wandb_viz_nerf_angles`: Number of angles in the 360-degree renderings [Optional, default set to 20]
- `--wandb_viz_nerf_distance`: Camera distance to visualize Scene from for 360-degree renderings on Weights & Biases [Optional, default set to 3]

We also wrote a detailed report on [Variable Bitrate Neural Fields](https://wandb.ai/geekyrakshit/kaolin-wisp-integration/reports/Variable-Bitrate-Neural-Fields--VmlldzozMDE0MDY0) and its usage with kaolin-wisp. The report was published in our blog [Fully-Connected](https://wandb.ai/fully-connected).

[![wandb-github-badge-gradient](https://user-images.githubusercontent.com/19887676/205284775-5a60ee8a-1e6f-4728-8fd7-a38fc32d9224.svg)](https://wandb.ai/geekyrakshit/kaolin-wisp-integration)
