### PR TITLE
Updated grid + AS api

### DIFF
--- a/wisp/accelstructs/__init__.py
+++ b/wisp/accelstructs/__init__.py
@@ -7,3 +7,4 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 from .octree_as import OctreeAS
+from .aabb_as import AxisAlignedBBoxAS

--- a/wisp/accelstructs/aabb_as.py
+++ b/wisp/accelstructs/aabb_as.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# NVIDIA CORPORATION & AFFILIATES and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
+
+from __future__ import annotations
+from wisp.accelstructs.octree_as import OctreeAS
+import wisp.ops.spc as wisp_spc_ops
+
+
+class AxisAlignedBBoxAS(OctreeAS):
+    """Axis Aligned Bounding Box, as a bottom-level acceleration structure class.
+    Can be used to to quickly query cells occupancy, and trace rays against the volume.
+    """
+    
+    def __init__(self):
+        """Initializes a simple acceleration structure of an AABB (axis aligned bounding box). """
+        # Builds a root-only octree, of one level, which is essentially a bounding box.
+        # Useful for hacking together a quick AABB (axis aligned bounding box) tracer.
+        octree = wisp_spc_ops.create_dense_octree(1)
+        super().__init__(octree)
+
+    def name(self) -> str:
+        return "AABB"

--- a/wisp/models/grids/__init__.py
+++ b/wisp/models/grids/__init__.py
@@ -8,5 +8,6 @@
 
 from .blas_grid import *
 from .octree_grid import *
+from .codebook_grid import *
 from .hash_grid import * 
 from .triplanar_grid import *

--- a/wisp/models/grids/blas_grid.py
+++ b/wisp/models/grids/blas_grid.py
@@ -6,23 +6,24 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
-import torch
-import torch.nn.functional as F
+from abc import ABC, abstractmethod
 import torch.nn as nn
 
-class BLASGrid(nn.Module):
-    """This is an abstract base class for a feature grid that uses an accelstruct to speed up operations.
-    
-    Classes which inherit the BLASGrid are generally compatible with PackedTracers.
+
+class BLASGrid(nn.Module, ABC):
     """
+    BLASGrids (commonly referred in documentation as simply "grids"), represent feature grids in Wisp.
+    BLAS: "Bottom Level Acceleration Structure", to signify this structure is the backbone that captures
+    a neural field's contents, in terms of both features and occupancy for speeding up queries.
 
-    def blas_initialized(self):
-        """This function is used to determine if the BLAS needs to be built.
+    This is an abstract base class that uses some spatial acceleration structure under the hood, to speed up operations
+    such as coordinate based queries or ray tracing.
+    Classes which inherit the BLASGrid are generally compatible with BaseTracers to support such operations
+    (see: raymarch(), raytrace(), query()).
 
-        Will return False if the blas construction is deferred.
-        """
-        return self.blas.initialized
-
+    Grids are usually employed as building blocks within neural fields (see: BaseNeuralField),
+    possibly paired with decoders to form a neural field.
+    """
     def raymarch(self, *args, **kwargs):
         """By default, this function will use the equivalent BLAS function unless overridden for custom behaviour.
         """
@@ -37,3 +38,20 @@ class BLASGrid(nn.Module):
         """By default, this function will use the equivalent BLAS function unless overridden for custom behaviour.
         """
         return self.blas.query(*args, **kwargs)
+
+    @abstractmethod
+    def interpolate(self, coords, lod_idx):
+        """ Interpolates a feature value for the given coords using the grid support, in the given lod_idx
+        Args:
+            coords (torch.FloatTensor): coords of shape [batch, num_samples, 3] or [batch, 3]
+            lod_idx  (int): int specifying the index to the desired level of detail, if supported.
+        """
+        raise NotImplementedError('A BLASGrid should implement the interpolation functionality according to '
+                                  'the grid structure.')
+
+    def name(self) -> str:
+        """
+        Returns:
+            (str) A BLASGrid should be given a meaningful, human readable name.
+        """
+        return type(self).__name__

--- a/wisp/models/grids/codebook_grid.py
+++ b/wisp/models/grids/codebook_grid.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# NVIDIA CORPORATION & AFFILIATES and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
+
+from __future__ import annotations
+import logging as log
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import kaolin.ops.spc as spc_ops
+import wisp.ops.spc as wisp_spc_ops
+from wisp.models.grids.octree_grid import OctreeGrid
+from wisp.accelstructs import OctreeAS
+
+
+class CodebookOctreeGrid(OctreeGrid):
+    """This is a multiresolution feature grid where the octree stores indices into a fixed size codebook.
+    """
+    def __init__(
+        self,
+        accelstruct,
+        feature_dim         : int,
+        base_lod            : int,
+        num_lods            : int          = 1,
+        interpolation_type  : str          = 'linear',
+        multiscale_type     : str          = 'cat',
+        feature_std         : float        = 0.0,
+        feature_bias        : float        = 0.0,
+        codebook_bitwidth   : int          = 8
+    ):
+        """
+        Args:
+            accelstruct: Spatial acceleration structure which tracks the occupancy state of this grid.
+                         Used to speed up spatial queries and ray tracing operations.
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of the  octree for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            interpolation_type (str): The type of interpolation function used when querying features on the grid.
+                                      'linear' - uses trilinear interpolation from nearest 8 nodes.
+                                      'closest' - uses feature from nearest grid node.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
+            codebook_bitwidth (int): Codebook dictionary_size is set as 2**bitwidth
+        """
+        self.bitwidth = codebook_bitwidth
+        super().__init__(accelstruct=accelstruct,
+                         feature_dim=feature_dim,
+                         base_lod=base_lod,
+                         num_lods=num_lods,
+                         interpolation_type=interpolation_type,
+                         multiscale_type=multiscale_type,
+                         feature_std=feature_std,
+                         feature_bias=feature_bias)
+
+    @classmethod
+    def make_dense(cls,
+                   feature_dim        : int,
+                   base_lod           : int,
+                   num_lods           : int          = 1,
+                   interpolation_type : str          = 'linear',
+                   multiscale_type    : str          = 'cat',
+                   feature_std        : float        = 0.0,
+                   feature_bias       : float        = 0.0,
+                   codebook_bitwidth   : int         = 8) -> CodebookOctreeGrid:
+        """Builds a fully occupied CodebookOctreeGrid with `base_lod + num_lods - 1` levels.
+
+        Args:
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of the  octree for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            interpolation_type (str): The type of interpolation function used when querying features on the grid.
+                                      'linear' - uses trilinear interpolation from nearest 8 nodes.
+                                      'closest' - uses feature from nearest grid node.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
+            codebook_bitwidth (int): Codebook dictionary_size is set as 2**bitwidth
+
+        Returns:
+            (CodebookOctreeGrid): A new instance of an OctreeGrid at full occupancy.
+        """
+        max_lod = OctreeGrid.max_octree_lod(base_lod, num_lods)
+        blas = OctreeAS.make_dense(level=max_lod)
+        grid = cls(accelstruct=blas, feature_dim=feature_dim, base_lod=base_lod, num_lods=num_lods,
+                   interpolation_type=interpolation_type, multiscale_type=multiscale_type,
+                   feature_std=feature_std, feature_bias=feature_bias, codebook_bitwidth=codebook_bitwidth)
+        return grid
+
+    @classmethod
+    def from_mesh(cls,
+                  mesh_path: str,
+                  num_samples_on_mesh: int,
+                  feature_dim: int,
+                  base_lod: int,
+                  num_lods: int = 1,
+                  interpolation_type: str = 'linear',
+                  multiscale_type: str = 'cat',
+                  feature_std: float = 0.0,
+                  feature_bias: float = 0.0,
+                  codebook_bitwidth: int = 8) -> CodebookOctreeGrid:
+        """Builds the CodebookOctreeGrid from point samples over mesh faces.
+        Samples will be quantized to populate the octree cells.
+        This method is not guaranteed to reproduce a perfect mesh structure without "holes",
+        but achieves a very good approximation with high probability.
+
+        Args:
+            mesh_path (str): Path to an OBJ file with a mesh to initialize the octree (only supports OBJ for now).
+            num_samples_on_mesh (int): The number of samples to be generated on the mesh surface.
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of the  octree for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            interpolation_type (str): The type of interpolation function used when querying features on the grid.
+                                      'linear' - uses trilinear interpolation from nearest 8 nodes.
+                                      'closest' - uses feature from nearest grid node.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
+            codebook_bitwidth (int): Codebook dictionary_size is set as 2**bitwidth
+
+        Returns:
+            (CodebookOctreeGrid): A new instance of an CodebookOctreeGrid with occupancy initialized from
+            samples over the mesh faces.
+        """
+        max_lod = OctreeGrid.max_octree_lod(base_lod, num_lods)
+        blas = OctreeAS.from_mesh(mesh_path, level=max_lod, sample_tex=False, num_samples=num_samples_on_mesh)
+        grid = cls(accelstruct=blas, feature_dim=feature_dim, base_lod=base_lod, num_lods=num_lods,
+                   interpolation_type=interpolation_type, multiscale_type=multiscale_type,
+                   feature_std=feature_std, feature_bias=feature_bias, codebook_bitwidth=codebook_bitwidth)
+        return grid
+
+    @classmethod
+    def from_pointcloud(cls,
+                        pointcloud: torch.FloatTensor,
+                        feature_dim: int,
+                        base_lod: int,
+                        num_lods: int = 1,
+                        interpolation_type: str = 'linear',
+                        multiscale_type: str = 'cat',
+                        feature_std: float = 0.0,
+                        feature_bias: float = 0.0,
+                        codebook_bitwidth: int = 8) -> CodebookOctreeGrid:
+        """Builds the CodebookOctreeGrid, initializing it with a pointcloud.
+        The cells occupancy will be determined by points occupying the octree cells.
+
+        Args:
+            pointcloud (torch.FloatTensor): 3D coordinates of shape [num_coords, 3] in normalized space [-1, 1].
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of the  octree for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            interpolation_type (str): The type of interpolation function used when querying features on the grid.
+                                      'linear' - uses trilinear interpolation from nearest 8 nodes.
+                                      'closest' - uses feature from nearest grid node.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
+            codebook_bitwidth (int): Codebook dictionary_size is set as 2**bitwidth
+
+        Returns:
+            (CodebookOctreeGrid): A new instance of an CodebookOctreeGrid with occupancy initialized from the pointcloud.
+        """
+        max_lod = OctreeGrid.max_octree_lod(base_lod, num_lods)
+        blas = OctreeAS.from_pointcloud(pointcloud, level=max_lod)
+        grid = cls(accelstruct=blas, feature_dim=feature_dim, base_lod=base_lod, num_lods=num_lods,
+                   interpolation_type=interpolation_type, multiscale_type=multiscale_type,
+                   feature_std=feature_std, feature_bias=feature_bias, codebook_bitwidth=codebook_bitwidth)
+        return grid
+
+    def init_feature_structure(self):
+        """ Initializes everything related to the features stored in the codebook octree structure. """
+        # Assumes the occupancy structure have been initialized (the BLAS: Bottom Level Accelerated Structure).
+        if self.interpolation_type == 'linear':
+            self.points_dual, self.pyramid_dual, self.trinkets, self.parents = \
+                    wisp_spc_ops.make_trilinear_spc(self.blas.points, self.blas.pyramid)
+            log.info("Built dual octree and trinkets")
+            
+        # Create the pyramid of features.
+        fpyramid = []
+        for al in self.active_lods:
+            if self.interpolation_type == 'linear':
+                fpyramid.append(self.pyramid_dual[0,al]+1)
+            elif self.interpolation_type == 'closest':
+                fpyramid.append(self.blas.pyramid[0,al]+1)
+            else:
+                raise Exception(f"Interpolation mode {self.interpolation_type} is not supported.")
+        self.num_feat = sum(fpyramid).long()
+        log.info(f"# Feature Vectors: {self.num_feat}")
+
+        self.dictionary_size = 2 ** self.bitwidth
+
+        self.dictionary = nn.ParameterList([])
+        for i in range(len(self.active_lods)):
+            fts = torch.zeros(self.dictionary_size, self.feature_dim)
+            fts += torch.randn_like(fts) * self.feature_std
+            self.dictionary.append(nn.Parameter(fts))
+
+        self.features = nn.ParameterList([]) 
+        
+        for i in range(len(self.active_lods)):
+            fts = torch.zeros(fpyramid[i], self.dictionary_size)
+            fts += torch.randn_like(fts) * self.feature_std
+            self.features.append(nn.Parameter(fts))
+
+    def bake(self):
+        for i, f in enumerate(self.features):
+            self.features[i] = nn.Parameter(f.max(dim=-1)[1].float())
+
+    def _index_features(self, feats, idx, lod_idx):
+        """Internal function. Returns the feats based on indices.
+
+        Args:
+            feats (torch.FloatTensor): tensor of feats of shape [num_feats, feat_dim]
+            idx (torch.LongTensor): indices of shape [num_indices]
+            lod_idx (int): index to `self.active_lods`.
+
+        Returns:
+            (torch.FloatTensor): tensor of feats of shape [num_indices, feat_dim]
+        """
+        # idx -> [N, 8]
+        # [1, 1, 256, 32] * [N, 8, 256, 1] -> [N, 8, 32]
+        
+        if self.training:
+            logits = feats[idx.long()]
+            y_soft = F.softmax(logits, dim=-1)
+            index = y_soft.max(-1, keepdim=True)[1]
+            y_hard = torch.zeros_like(
+                logits, memory_format=torch.legacy_contiguous_format
+            ).scatter_(-1, index, 1.0)
+            keys = y_hard - y_soft.detach() + y_soft
+            return (self.dictionary[lod_idx][None, None] * keys[..., None]).sum(-2)
+            
+            # TODO(ttakikawa): Replace with a cleaner / faster softmax implementation
+            #keys = F.softmax(feats[idx.long()], dim=-1)
+            #return softmax_dictionary(keys, self.dictionary[lod_idx])
+        else:
+            # [N, 8, 256] -> [N, 8]
+            #keys = feats[idx.long()].long()
+            keys = torch.max(feats[idx.long()], dim=-1)[1]
+            return self.dictionary[lod_idx][keys]
+    
+    def _interpolate(self, coords, feats, pidx, lod_idx):
+        """Query multiscale features.
+
+        Args:
+            coords (torch.FloatTensor): coords of shape [batch, num_samples, 3]
+            lod_idx  (int): int specifying the index to ``active_lods`` 
+            pidx (torch.LongTensor): point_hiearchy indices of shape [batch]
+            features (torch.FloatTensor): features to interpolate. If ``None``, will use `self.features`.
+
+        Returns:
+            (torch.FloatTensor): interpolated features of shape [batch, num_samples, feature_dim]
+        """
+        batch, num_samples = coords.shape[:2]
+
+        if self.interpolation_type == 'linear':
+            
+            fs = torch.zeros(batch, num_samples, self.feature_dim, device=coords.device)
+            
+            valid_mask = pidx > -1
+            valid_pidx = pidx[valid_mask]
+            if valid_pidx.shape[0] == 0:
+                return fs
+
+            corner_feats = self._index_features(feats, 
+                    self.trinkets.index_select(0, valid_pidx).long(), lod_idx)[:, None]
+            
+            pts = self.blas.points.index_select(0, valid_pidx)[:,None].repeat(1, coords.shape[1], 1)
+
+            coeffs = spc_ops.coords_to_trilinear_coeffs(coords[valid_mask], pts, self.active_lods[lod_idx])[..., None]
+            fs[valid_mask] = (corner_feats * coeffs).sum(-2)
+
+        elif self.interpolation_type == 'closest':
+            raise NotImplementedError
+        else:
+            raise Exception(f"Interpolation mode {self.interpolation_type} is not supported.")
+        
+        return fs
+
+    def name(self) -> str:
+        return "Codebook Grid"

--- a/wisp/models/grids/hash_grid.py
+++ b/wisp/models/grids/hash_grid.py
@@ -6,83 +6,97 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
+from __future__ import annotations
 import torch
-import torch.nn.functional as F
 import torch.nn as nn
 import numpy as np
 import logging as log
-import time
-import math
-
-from wisp.utils import PsDebugger, PerfTimer
-from wisp.ops.spc import sample_spc
-
-import wisp.ops.spc as wisp_spc_ops
-import wisp.ops.grid as grid_ops
-
-from wisp.models.grids import BLASGrid
-from wisp.models.decoders import BasicDecoder
-
 import kaolin.ops.spc as spc_ops
-
+import wisp.ops.grid as grid_ops
 from wisp.accelstructs import OctreeAS
+from wisp.models.grids import BLASGrid
+
 
 class HashGrid(BLASGrid):
-    """This is a feature grid where the features are defined in a codebook that is hashed.
-    """
+    """A feature grid where hashed feature pointers are stored as multi-LOD grid nodes,
+    and actual feature contents are stored in a hash table.
+    (see: Muller et al. 2022, Instant-NGP: https://nvlabs.github.io/instant-ngp/)
 
+    The occupancy state (e.g. BLAS, Bottom Level Acceleration Structure) is tracked separately from the feature
+    volume, and relies on heuristics such as pruning for keeping it aligned with the feature structure.
+    """
     def __init__(self, 
         feature_dim        : int,
-        interpolation_type : str   = 'linear',
-        multiscale_type    : str   = 'cat',
+        base_lod           : int   = None,
+        num_lods           : int   = 1,
+        multiscale_type    : str   = 'sum',
         feature_std        : float = 0.0,
         feature_bias       : float = 0.0,
-        codebook_bitwidth  : int   = 16,
-        blas_level         : int   = 7,
-        **kwargs
+        codebook_bitwidth  : int   = 8,
+        tree_type          : str   = None,
+        min_grid_res       : int   = None,
+        max_grid_res       : int   = None,
+        blas_level: int = 7,
     ):
-        """Initialize the hash grid class.
+        """Builds a HashGrid instance, including the feature structure and an underlying BLAS for fast queries.
 
         Args:
             feature_dim (int): The dimension of the features stored on the grid.
-            interpolation_type (str): The type of interpolation function.
-            multiscale_type (str): The type of multiscale aggregation. Usually 'sum' or 'cat'.
-                                   Note that 'cat' will change the decoder input dimension.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of for which features are defined. This arg is only used
+                            when the HashGrid is initialized with the tree_type="quad" pattern.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
             feature_std (float): The features are initialized with a Gaussian distribution with the given
                                  standard deviation.
-            feature_bias (float): The mean of the Gaussian distribution.
-            codebook_bitwidth (int): The bitwidth of the codebook.
-            blas_level (int): The level of the octree to be used as the BLAS.
-        
-        Returns:
-            (void): Initializes the class.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
+            codebook_bitwidth (int): Codebook dictionary_size is set as 2**bitwidth
+            tree_type (str): How to determine the resolution of the grid.
+                "geometric" - uses the geometric sequence initialization from InstantNGP,
+                "quad" -  uses an octree sampling pattern.
+            min_grid_res (int): min resolution of the feature grid. Used only for "geometric" initialization.
+            max_grid_res (int): max resolution of the feature grid. Used only for "geometric" initialization.
+            blas_level (int): The level of the octree to be used as the BLAS (bottom level acceleration structure).
         """
         super().__init__()
+        # Feature Structure
         self.feature_dim = feature_dim
-        self.interpolation_type = interpolation_type
+        self.num_lods = num_lods
         self.multiscale_type = multiscale_type
-
         self.feature_std = feature_std
         self.feature_bias = feature_bias
         self.codebook_bitwidth = codebook_bitwidth
-        self.blas_level = blas_level
 
-        self.kwargs = kwargs
-    
-        self.blas = OctreeAS()
-        self.blas.init_dense(self.blas_level)
+        # Occupancy Structure
+        self.blas_level = blas_level
+        self.blas = OctreeAS.make_dense(level=self.blas_level)
         self.dense_points = spc_ops.unbatched_get_level_points(self.blas.points, self.blas.pyramid, self.blas_level).clone()
         self.num_cells = self.dense_points.shape[0]
         self.occupancy = torch.zeros(self.num_cells)
 
-    def init_from_octree(self, base_lod, num_lods):
+        if tree_type == 'quad':
+            if base_lod is None:
+                raise ValueError("'base_lod' must be specified with tree_type == 'quad'")
+            self._init_from_octree(base_lod)
+        elif tree_type == 'geometric':
+            if max_grid_res is None or min_grid_res is None:
+                raise ValueError("'max_grid_res' must be specified with tree_type == 'geometric'")
+            self._init_from_geometric(min_grid_res, max_grid_res)
+        else:
+            raise ValueError(f"tree_type == '{tree_type}' not supported")
+
+    def _init_from_octree(self, base_lod):
         """Builds the multiscale hash grid with an octree sampling pattern.
         """
-        octree_lods = [base_lod + x for x in range(num_lods)]
+        octree_lods = [base_lod + x for x in range(self.num_lods)]
         resolutions = [2 ** lod for lod in octree_lods]
-        self.init_from_resolutions(resolutions)
+        self._init_from_resolutions(resolutions)
 
-    def init_from_geometric(self, min_width, max_width, num_lods):
+    def _init_from_geometric(self, min_width, max_width):
         """Build the multiscale hash grid with a geometric sequence.
 
         This is an implementation of the geometric multiscale grid from 
@@ -90,11 +104,11 @@ class HashGrid(BLASGrid):
 
         See Section 3 Equations 2 and 3 for more details.
         """
-        b = np.exp((np.log(max_width) - np.log(min_width)) / (num_lods-1))
-        resolutions = [int(1 + np.floor(min_width*(b**l))) for l in range(num_lods)]
-        self.init_from_resolutions(resolutions)
+        b = np.exp((np.log(max_width) - np.log(min_width)) / (self.num_lods-1))
+        resolutions = [int(1 + np.floor(min_width*(b**l))) for l in range(self.num_lods)]
+        self._init_from_resolutions(resolutions)
     
-    def init_from_resolutions(self, resolutions):
+    def _init_from_resolutions(self, resolutions):
         """Build a multiscale hash grid from a list of resolutions.
         """
         self.resolutions = resolutions
@@ -112,6 +126,76 @@ class HashGrid(BLASGrid):
             fts = torch.zeros(min(self.codebook_size, num_pts), self.feature_dim)
             fts += torch.randn_like(fts) * self.feature_std
             self.codebook.append(nn.Parameter(fts))
+
+    @classmethod
+    def from_octree(cls,
+                    feature_dim        : int,
+                    base_lod           : int   = 2,
+                    num_lods           : int   = 1,
+                    multiscale_type    : str   = 'sum',
+                    feature_std        : float = 0.0,
+                    feature_bias       : float = 0.0,
+                    codebook_bitwidth  : int   = 8,
+                    blas_level         : int   = 7) -> HashGrid:
+        """
+        Builds a hash grid using an octree sampling pattern.
+
+        Args:
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
+            codebook_bitwidth (int): Codebook dictionary_size is set as 2**bitwidth
+            blas_level (int): The level of the octree to be used as the BLAS (bottom level acceleration structure).
+                The HashGrid is backed
+        """
+        return cls(feature_dim=feature_dim, base_lod=base_lod, num_lods=num_lods, multiscale_type=multiscale_type,
+                   feature_std=feature_std, feature_bias=feature_bias, codebook_bitwidth=codebook_bitwidth,
+                   blas_level=blas_level, tree_type='quad')
+
+    @classmethod
+    def from_geometric(cls,
+                       feature_dim        : int,
+                       num_lods           : int,
+                       multiscale_type    : str   = 'sum',
+                       feature_std        : float = 0.0,
+                       feature_bias       : float = 0.0,
+                       codebook_bitwidth  : int   = 8,
+                       min_grid_res       : int   = 16,
+                       max_grid_res       : int   = None,
+                       blas_level: int = 7) -> HashGrid:
+        """
+        Builds a hash grid using the geometric sequence initialization pattern from Muller et al. 2022 (Instant-NGP).
+
+        Args:
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
+            codebook_bitwidth (int): Codebook dictionary_size is set as 2**bitwidth
+            min_grid_res (int): min resolution of the feature grid.
+            max_grid_res (int): max resolution of the feature grid.
+            blas_level (int): The level of the octree to be used as the BLAS (bottom level acceleration structure).
+        """
+        return cls(feature_dim=feature_dim, num_lods=num_lods, multiscale_type=multiscale_type,
+                   feature_std=feature_std, feature_bias=feature_bias, codebook_bitwidth=codebook_bitwidth,
+                   blas_level=blas_level, min_grid_res=min_grid_res, max_grid_res=max_grid_res, tree_type='geometric')
 
     def freeze(self):
         """Freezes the feature grid.
@@ -145,7 +229,7 @@ class HashGrid(BLASGrid):
         else:
             raise NotImplementedError
 
-    def raymarch(self, rays, num_samples=64, level=None, raymarch_type='voxel'):
+    def raymarch(self, rays, num_samples, level=None, raymarch_type='voxel'):
         """Mostly a wrapper over OctreeAS.raymarch. See corresponding function for more details.
 
         Important detail: the OctreeGrid raymarch samples over the coarsest LOD where features are available.

--- a/wisp/models/grids/octree_grid.py
+++ b/wisp/models/grids/octree_grid.py
@@ -6,42 +6,36 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
+from __future__ import annotations
 import torch
-import torch.nn.functional as F
 import torch.nn as nn
-import numpy as np
 import logging as log
-import time
-import math
-from wisp.utils import PsDebugger, PerfTimer
-from wisp.ops.spc import sample_spc
-
 import wisp.ops.spc as wisp_spc_ops
-
 from wisp.models.grids import BLASGrid
-from wisp.models.decoders import BasicDecoder
-
 import kaolin.ops.spc as spc_ops
-
 from wisp.accelstructs import OctreeAS
+
 
 class OctreeGrid(BLASGrid):
     """This is a multiscale feature grid where the features are defined on the BLAS, the octree.
     """
 
-    def __init__(self, 
-        feature_dim        : int,
-        base_lod           : int   = 0,
-        num_lods           : int   = 1, 
-        interpolation_type : str   = 'linear',
-        multiscale_type    : str   = 'cat',
-        feature_std        : float = 0.0,
-        feature_bias       : float = 0.0,
-        **kwargs
+    def __init__(
+        self,
+        accelstruct,
+        feature_dim         : int,
+        base_lod            : int,
+        num_lods            : int          = 1, 
+        interpolation_type  : str          = 'linear',
+        multiscale_type     : str          = 'cat',
+        feature_std         : float        = 0.0,
+        feature_bias        : float        = 0.0
     ):
         """Initialize the octree grid class.
 
         Args:
+            accelstruct: Spatial acceleration structure which tracks the occupancy state of this grid.
+                         Used to speed up spatial queries and ray tracing operations.
             feature_dim (int): The dimension of the features stored on the grid.
             base_lod (int): The base LOD of the feature grid. This is the lowest LOD of the SPC octree
                             for which features are defined.
@@ -52,7 +46,8 @@ class OctreeGrid(BLASGrid):
             feature_std (float): The features are initialized with a Gaussian distribution with the given
                                  standard deviation.
             feature_bias (float): The mean of the Gaussian distribution.
-        
+            sample_tex (bool): If True, will also sample textures and store it in the accelstruct.
+            num_samples (int): The number of samples to be generated on the mesh surface.
         Returns:
             (void): Initializes the class.
         """
@@ -66,72 +61,197 @@ class OctreeGrid(BLASGrid):
         self.feature_std = feature_std
         self.feature_bias = feature_bias
 
-        self.kwargs = kwargs
-
         # List of octree levels which are optimized.
         self.active_lods = [self.base_lod + x for x in range(self.num_lods)]
-        self.max_lod = self.num_lods + self.base_lod - 1
+        self.max_lod = OctreeGrid.max_octree_lod(self.base_lod, self.num_lods)
 
-        log.info(f"Active LODs: {self.active_lods}")
-        
-        self.blas = OctreeAS()
+        log.info(f"Active LODs: {self.active_lods}")    # TODO(operel): move into trainer
 
-    def init_from_mesh(self, mesh_path, level=None, sample_tex=False, num_samples=100000000):
-        """Builds the grid from a path to the mesh.
+        self.blas = accelstruct
+        if self.num_lods > 0:
+            self.init_feature_structure()
+
+    @staticmethod
+    def max_octree_lod(base_lod, num_lods) -> int:
         """
-        if level is None:
-            level = self.max_lod
-        self.blas.init_from_mesh(mesh_path, level, sample_tex=sample_tex, num_samples=num_samples)
-        self._init()
+        Returns:
+            (int): The highest level-of-detail maintaining features in this Octree grid.
+        """
+        return base_lod + num_lods - 1
 
-    def init_from_pointcloud(self, pointcloud, level=None):
-        """Builds the grid from a pointcloud.
+    @classmethod
+    def make_dense(cls,
+                   feature_dim        : int,
+                   base_lod           : int,
+                   num_lods           : int          = 1,
+                   interpolation_type : str          = 'linear',
+                   multiscale_type    : str          = 'cat',
+                   feature_std        : float        = 0.0,
+                   feature_bias       : float        = 0.0) -> OctreeGrid:
+        """Builds a fully occupied OctreeGrid with `base_lod + num_lods - 1` levels.
 
         Args:
-            pointcloud (torch.FloatTensor): 3D coordinates of shape [num_coords, 3] in 
-                                            normalized space [-1, 1].
-            level (int): The depth of the octree. If None, uses the max LOD.
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of the  octree for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            interpolation_type (str): The type of interpolation function used when querying features on the grid.
+                                      'linear' - uses trilinear interpolation from nearest 8 nodes.
+                                      'closest' - uses feature from nearest grid node.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
 
         Returns:
-            (void): Will initialize the OctreeAS object.
+            (OctreeGrid): A new instance of an OctreeGrid at full occupancy.
         """
-        if level is None:
-            level = self.max_lod
-        self.blas.init_from_pointcloud(pointcloud, level)
-        self._init()
+        max_lod = OctreeGrid.max_octree_lod(base_lod, num_lods)
+        blas = OctreeAS.make_dense(level=max_lod)
+        grid = cls(accelstruct=blas, feature_dim=feature_dim, base_lod=base_lod, num_lods=num_lods,
+                   interpolation_type=interpolation_type, multiscale_type=multiscale_type,
+                   feature_std=feature_std, feature_bias=feature_bias)
+        return grid
 
-    def init_dense(self, level=None):
-        """Builds a dense octree grid.
+    @classmethod
+    def from_mesh(cls,
+                  mesh_path: str,
+                  num_samples_on_mesh: int,
+                  feature_dim: int,
+                  base_lod: int,
+                  num_lods: int = 1,
+                  interpolation_type: str = 'linear',
+                  multiscale_type: str = 'cat',
+                  feature_std: float = 0.0,
+                  feature_bias: float = 0.0) -> OctreeGrid:
+        """Builds the OctreeGrid from point samples over mesh faces.
+        Samples will be quantized to populate the octree cells.
+        This method is not guaranteed to reproduce a perfect mesh structure without "holes",
+        but achieves a very good approximation with high probability.
 
         Args:
-            level (int): The depth of the octree. If None, uses the max LOD.
+            mesh_path (str): Path to an OBJ file with a mesh to initialize the octree (only supports OBJ for now).
+            num_samples (int): The number of samples to be generated on the mesh surface.
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of the  octree for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            interpolation_type (str): The type of interpolation function used when querying features on the grid.
+                                      'linear' - uses trilinear interpolation from nearest 8 nodes.
+                                      'closest' - uses feature from nearest grid node.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
 
         Returns:
-            (void): Will initialize the OctreeAS object.
+            (OctreeGrid): A new instance of an OctreeGrid with occupancy initialized from samples over the mesh faces.
         """
-        if level is None:
-            level = self.max_lod
-        self.blas.init_dense(level)
-        self._init()
+        max_lod = OctreeGrid.max_octree_lod(base_lod, num_lods)
+        blas = OctreeAS.from_mesh(mesh_path, level=max_lod, sample_tex=False, num_samples=num_samples_on_mesh)
+        grid = cls(accelstruct=blas, feature_dim=feature_dim, base_lod=base_lod, num_lods=num_lods,
+                   interpolation_type=interpolation_type, multiscale_type=multiscale_type,
+                   feature_std=feature_std, feature_bias=feature_bias)
+        return grid
 
-    def init(self, octree):
-        """Initializes auxillary state from an octree tensor.
+    @classmethod
+    def from_pointcloud(cls,
+                        pointcloud: torch.FloatTensor,
+                        feature_dim: int,
+                        base_lod: int,
+                        num_lods: int = 1,
+                        interpolation_type: str = 'linear',
+                        multiscale_type: str = 'cat',
+                        feature_std: float = 0.0,
+                        feature_bias: float = 0.0) -> OctreeGrid:
+        """Builds the OctreeGrid, initializing it with a pointcloud.
+        The cells occupancy will be determined by points occupying the octree cells.
 
         Args:
-            octree (torch.ByteTensor): SPC octree tensor.
+            pointcloud (torch.FloatTensor): 3D coordinates of shape [num_coords, 3] in normalized space [-1, 1].
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of the  octree for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            interpolation_type (str): The type of interpolation function used when querying features on the grid.
+                                      'linear' - uses trilinear interpolation from nearest 8 nodes.
+                                      'closest' - uses feature from nearest grid node.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
 
         Returns:
-            (void): Will initialize the OctreeAS object.
+            (OctreeGrid): A new instance of an OctreeGrid with occupancy initialized from the pointcloud.
         """
-        self.blas.init(octree)
-        self._init()
+        max_lod = OctreeGrid.max_octree_lod(base_lod, num_lods)
+        blas = OctreeAS.from_pointcloud(pointcloud, level=max_lod)
+        grid = cls(accelstruct=blas, feature_dim=feature_dim, base_lod=base_lod, num_lods=num_lods,
+                   interpolation_type=interpolation_type, multiscale_type=multiscale_type,
+                   feature_std=feature_std, feature_bias=feature_bias)
+        return grid
 
-    def _init(self):
-        """Initializes everything that is not the BLAS.
+    @classmethod
+    def from_spc(cls,
+                 spc_octree: torch.FloatTensor,
+                 feature_dim: int,
+                 base_lod: int,
+                 num_lods: int = 1,
+                 interpolation_type: str = 'linear',
+                 multiscale_type: str = 'cat',
+                 feature_std: float = 0.0,
+                 feature_bias: float = 0.0) -> OctreeGrid:
+        """Builds the OctreeGrid, initializing it's occupancy state with a Structured Point Cloud (SPC).
+        The octree cells occupancy will be determined by the SPC cells.
+        SPCs are compressed, sparse volumetric data structures used for accelerated point queries and ray tracing ops.
+
+        Args:
+            spc_octree (torch.ByteTensor):
+                A tensor which holds the topology of a Structured Point Cloud (SPC).
+                Each byte represents a single octree cell's occupancy (that is, each bit of that byte represents
+                the occupancy status of a child octree cell), yielding 8 bits for 8 cells.
+                See also https://kaolin.readthedocs.io/en/latest/notes/spc_summary.html
+            feature_dim (int): The dimension of the features stored on the grid.
+            base_lod (int): The base LOD of the feature grid.
+                            This is the lowest LOD of the  octree for which features are defined.
+            num_lods (int): The number of LODs for which features are defined. Starts at base_lod.
+                            i.e. base_lod=4 and num_lods=5 means features are kept for levels 5, 6, 7, 8.
+            interpolation_type (str): The type of interpolation function used when querying features on the grid.
+                                      'linear' - uses trilinear interpolation from nearest 8 nodes.
+                                      'closest' - uses feature from nearest grid node.
+            multiscale_type (str): The type of multiscale aggregation.
+                                   'sum' - aggregates features from different LODs with summation.
+                                   'cat' - aggregates features from different LODs with concatenation.
+                                   Note that 'cat' will change the decoder input dimension to num_lods * feature_dim.
+            feature_std (float): The features are initialized with a Gaussian distribution with the given
+                                 standard deviation.
+            feature_bias (float): The features are initialized with a Gaussian distribution with the given mean.
+
+        Returns:
+            (OctreeGrid): A new instance of an OctreeGrid with occupancy initialized from the SPC topology.
         """
-        if not self.blas_initialized():
-            assert False and "Octree BLAS not initialized. _init is private."
+        blas = OctreeAS(spc_octree)
+        grid = cls(accelstruct=blas, feature_dim=feature_dim, base_lod=base_lod, num_lods=num_lods,
+                   interpolation_type=interpolation_type, multiscale_type=multiscale_type,
+                   feature_std=feature_std, feature_bias=feature_bias)
+        return grid
 
+    def init_feature_structure(self):
+        """ Initializes everything related to the features stored in the codebook octree structure. """
+
+        # Assumes the occupancy structure have been initialized (the BLAS: Bottom Level Accelerated Structure).
         # Build the trinket structure
         if self.interpolation_type in ['linear']:
             self.points_dual, self.pyramid_dual, self.trinkets, self.parents = \
@@ -220,12 +340,7 @@ class OctreeGrid(BLASGrid):
 
         Args:
             coords (torch.FloatTensor): coords of shape [batch, num_samples, 3] or [batch, 3]
-            lod_idx  (int): int specifying the index to ``active_lods`` 
-            pidx (torch.LongTensor): Optional, for advanced users only.
-                pidx is the indices of underlying BLAS cells corresponding to the
-                input coords. If specified, can save an "extra query" to the underlying acceleration structure.
-                pidx assumes a tensor of indices of shape [batch] (for example, an OctreeAS
-                should specify the SPC's point_hierarchy indices).
+            lod_idx  (int): int specifying the index to ``active_lods``
             features (torch.FloatTensor): features to interpolate. If ``None``, will use `self.features`.
 
         Returns:
@@ -275,128 +390,12 @@ class OctreeGrid(BLASGrid):
             
             return feats.reshape(*output_shape, self.feature_dim)
 
-    def raymarch(self, rays, num_samples=64, level=None, raymarch_type='voxel'):
+    def raymarch(self, rays, num_samples, level=None, raymarch_type='voxel'):
         """Mostly a wrapper over OctreeAS.raymarch. See corresponding function for more details.
 
         Important detail: the OctreeGrid raymarch samples over the coarsest LOD where features are available.
         """
         return self.blas.raymarch(rays, num_samples=num_samples, level=self.base_lod, raymarch_type=raymarch_type)
 
-class CodebookOctreeGrid(OctreeGrid):
-    """This is a multiresolution feature grid where the octree stores indices into a fixed size codebook.
-    """
-
-    def _init(self):
-        """Initializes everything that is not the BLAS.
-        """
-        if not self.blas_initialized():
-            assert False and "Octree BLAS not initialized. _init is private."
-        if self.interpolation_type == 'linear':
-            self.points_dual, self.pyramid_dual, self.trinkets, self.parents = \
-                    wisp_spc_ops.make_trilinear_spc(self.blas.points, self.blas.pyramid)
-            log.info("Built dual octree and trinkets")
-
-        # Create the pyramid of features.
-        fpyramid = []
-        for al in self.active_lods:
-            if self.interpolation_type == 'linear':
-                fpyramid.append(self.pyramid_dual[0,al]+1)
-            elif self.interpolation_type == 'closest':
-                fpyramid.append(self.blas.pyramid[0,al]+1)
-            else:
-                raise Exception(f"Interpolation mode {self.interpolation_type} is not supported.")
-        self.num_feat = sum(fpyramid).long()
-        log.info(f"# Feature Vectors: {self.num_feat}")
-
-        self.bitwidth = self.kwargs['codebook_bitwidth']
-
-        self.dictionary_size = 2**self.bitwidth
-
-        self.dictionary = nn.ParameterList([])
-        for i in range(len(self.active_lods)):
-            fts = torch.zeros(self.dictionary_size, self.feature_dim)
-            fts += torch.randn_like(fts) * self.feature_std
-            self.dictionary.append(nn.Parameter(fts))
-
-        self.features = nn.ParameterList([]) 
-        
-        for i in range(len(self.active_lods)):
-            fts = torch.zeros(fpyramid[i], self.dictionary_size)
-            fts += torch.randn_like(fts) * self.feature_std
-            self.features.append(nn.Parameter(fts))
-
-    def bake(self):
-        for i, f in enumerate(self.features):
-            self.features[i] = nn.Parameter(f.max(dim=-1)[1].float())
-
-    def _index_features(self, feats, idx, lod_idx):
-        """Internal function. Returns the feats based on indices.
-
-        Args:
-            feats (torch.FloatTensor): tensor of feats of shape [num_feats, feat_dim]
-            idx (torch.LongTensor): indices of shape [num_indices]
-            lod_idx (int): index to `self.active_lods`.
-
-        Returns:
-            (torch.FloatTensor): tensor of feats of shape [num_indices, feat_dim]
-        """
-        # idx -> [N, 8]
-        # [1, 1, 256, 32] * [N, 8, 256, 1] -> [N, 8, 32]
-        
-        if self.training:
-            logits = feats[idx.long()]
-            y_soft = F.softmax(logits, dim=-1)
-            index = y_soft.max(-1, keepdim=True)[1]
-            y_hard = torch.zeros_like(
-                logits, memory_format=torch.legacy_contiguous_format
-            ).scatter_(-1, index, 1.0)
-            keys = y_hard - y_soft.detach() + y_soft
-            return (self.dictionary[lod_idx][None, None] * keys[..., None]).sum(-2)
-            
-            # TODO(ttakikawa): Replace with a cleaner / faster softmax implementation
-            #keys = F.softmax(feats[idx.long()], dim=-1)
-            #return softmax_dictionary(keys, self.dictionary[lod_idx])
-        else:
-            # [N, 8, 256] -> [N, 8]
-            #keys = feats[idx.long()].long()
-            keys = torch.max(feats[idx.long()], dim=-1)[1]
-            return self.dictionary[lod_idx][keys]
-    
-    def _interpolate(self, coords, feats, pidx, lod_idx):
-        """Query multiscale features.
-
-        Args:
-            coords (torch.FloatTensor): coords of shape [batch, num_samples, 3]
-            lod_idx  (int): int specifying the index to ``active_lods`` 
-            pidx (torch.LongTensor): point_hiearchy indices of shape [batch]
-            features (torch.FloatTensor): features to interpolate. If ``None``, will use `self.features`.
-
-        Returns:
-            (torch.FloatTensor): interpolated features of shape [batch, num_samples, feature_dim]
-        """
-        batch, num_samples = coords.shape[:2]
-
-        if self.interpolation_type == 'linear':
-            
-            fs = torch.zeros(batch, num_samples, self.feature_dim, device=coords.device)
-            
-            valid_mask = pidx > -1
-            valid_pidx = pidx[valid_mask]
-            if valid_pidx.shape[0] == 0:
-                return fs
-
-            corner_feats = self._index_features(feats, 
-                    self.trinkets.index_select(0, valid_pidx).long(), lod_idx)[:, None]
-            
-            pts = self.blas.points.index_select(0, valid_pidx)[:,None].repeat(1, coords.shape[1], 1)
-
-            coeffs = spc_ops.coords_to_trilinear_coeffs(coords[valid_mask], pts, self.active_lods[lod_idx])[..., None]
-            fs[valid_mask] = (corner_feats * coeffs).sum(-2)
-
-        elif self.interpolation_type == 'closest':
-            raise NotImplementedError
-        else:
-            raise Exception(f"Interpolation mode {self.interpolation_type} is not supported.")
-        
-        return fs
-
+    def name(self) -> str:
+        return "Octree Grid"

--- a/wisp/models/nefs/base_nef.py
+++ b/wisp/models/nefs/base_nef.py
@@ -22,8 +22,9 @@ class BaseNeuralField(nn.Module):
 
     TODO(ttakikawa): More complete documentation here.
     """
-    def __init__(self, 
-        grid_type          : str = 'OctreeGrid',
+    def __init__(self,
+        grid,
+        grid_type, # TODO (operel): to be removed in following MR
         interpolation_type : str = 'linear',
         multiscale_type    : str = 'none',
 
@@ -53,7 +54,6 @@ class BaseNeuralField(nn.Module):
     ):
         super().__init__()
 
-        self.grid_type = grid_type
         self.interpolation_type = interpolation_type
         self.raymarch_type = raymarch_type
         self.embedder_type = embedder_type
@@ -78,9 +78,10 @@ class BaseNeuralField(nn.Module):
         self.kwargs = kwargs
 
         self.grid = None
+        self.grid_type = grid_type
         self.decoder = None
         
-        self.init_grid()
+        self.grid = grid
         self.init_embedder()
         self.init_decoder()
         torch.cuda.empty_cache()
@@ -95,11 +96,6 @@ class BaseNeuralField(nn.Module):
 
     def init_decoder(self):
         """Initialize the decoder object.
-        """
-        return
-
-    def init_grid(self):
-        """Initialize the grid object.
         """
         return
 

--- a/wisp/models/nefs/nerf.py
+++ b/wisp/models/nefs/nerf.py
@@ -64,25 +64,6 @@ class NeuralRadianceField(BaseNeuralField):
                                           layer=get_layer_class(self.layer_type), num_layers=self.num_layers+1,
                                           hidden_dim=self.hidden_dim, skip=[])
 
-    def init_grid(self):
-        """Initialize the grid object.
-        """
-        if self.grid_type == "OctreeGrid":
-            grid_class = OctreeGrid
-        elif self.grid_type == "CodebookOctreeGrid":
-            grid_class = CodebookOctreeGrid
-        elif self.grid_type == "TriplanarGrid":
-            grid_class = TriplanarGrid
-        elif self.grid_type == "HashGrid":
-            grid_class = HashGrid
-        else:
-            raise NotImplementedError
-
-        self.grid = grid_class(self.feature_dim,
-                               base_lod=self.base_lod, num_lods=self.num_lods,
-                               interpolation_type=self.interpolation_type, multiscale_type=self.multiscale_type,
-                               **self.kwargs)
-
     def prune(self):
         """Prunes the blas based on current state.
         """
@@ -115,7 +96,7 @@ class NeuralRadianceField(BaseNeuralField):
                     return
 
                 octree = spc_ops.unbatched_points_to_octree(_points, self.grid.blas_level, sorted=True)
-                self.grid.blas.init(octree)
+                self.grid.blas = OctreeAS(octree)
             else:
                 raise NotImplementedError
 

--- a/wisp/models/nefs/neural_sdf.py
+++ b/wisp/models/nefs/neural_sdf.py
@@ -44,25 +44,6 @@ class NeuralSDFTex(BaseNeuralField):
                                     layer=get_layer_class(self.activation_type), num_layers=self.num_layers,
                                     hidden_dim=self.hidden_dim, skip=[])
 
-    def init_grid(self):
-        """Initialize the grid object.
-        """
-        if self.grid_type == "OctreeGrid":
-            grid_class = OctreeGrid
-        elif self.grid_type == "CodebookOctreeGrid":
-            grid_class = CodebookOctreeGrid
-        elif self.grid_type == "TriplanarGrid":
-            grid_class = TriplanarGrid
-        elif self.grid_type == "HashGrid":
-            grid_class = HashGrid
-        else:
-            raise NotImplementedError
-
-        self.grid = grid_class(self.feature_dim,
-                               base_lod=self.base_lod, num_lods=self.num_lods,
-                               interpolation_type=self.interpolation_type, multiscale_type=self.multiscale_type,
-                               **self.kwargs)
-
     def get_nef_type(self):
         """Returns a text keyword of the neural field type.
 

--- a/wisp/tracers/packed_rf_tracer.py
+++ b/wisp/tracers/packed_rf_tracer.py
@@ -43,7 +43,6 @@ class PackedRFTracer(BaseTracer):
             step_size (float): The step size between samples. Currently unused, but will be used for a new
                                sampling method in the future.
             bg_color (str): The background color to use.
-            TODO(ttakikawa): Might be able to simplify / remove
         """
         super().__init__(**kwargs)
         self.raymarch_type = raymarch_type


### PR DESCRIPTION
This changeset brings over a new api of ctors for the grids and acceleration structure.
Forcing the grid ctor to take an acceleration structure makes sure the grids are always initialized (there can't be a situation where one creates a grid but forgets to initialize it).
That will also make it easier to inject additional occupancy structures.

Signed-off-by: operel <operel@nvidia.com>