### PR TITLE
Remove pidx from interpolate and raymarching output

### DIFF
--- a/wisp/config_parser.py
+++ b/wisp/config_parser.py
@@ -584,6 +584,35 @@ def load_dataset(args):
                                    args.get_normals, args.sample_tex)
     return train_dataset
 
+def load_nef(args, grid):
+    if args.nef_type == 'NeuralRadianceField':
+        return NeuralRadianceField(
+            grid=grid,
+            pos_embedder=args.embedder_type,
+            view_embedder=args.embedder_type,
+            pos_multires=args.pos_multires,
+            view_multires=args.view_multires,
+            activation_type=args.activation_type,
+            layer_type=args.layer_type,
+            hidden_dim=args.hidden_dim,
+            num_layers=args.num_layers,
+            prune_density_decay=args.prune_density_decay,
+            prune_min_density=args.prune_min_density
+        )
+    elif args.nef_type == 'NeuralSDF':
+        return NeuralSDF(
+            grid=grid,
+            pos_embedder=args.embedder_type,
+            pos_multires=args.pos_multires,
+            position_input=args.position_input,
+            activation_type=args.activation_type,
+            layer_type=args.layer_type,
+            hidden_dim=args.hidden_dim,
+            num_layers=args.num_layers
+        )
+    else:
+        raise ValueError(f'Neural field {args.nef_type} is temporarily unsupported by the config parser.')
+
 def get_modules_from_config(args):
     """Utility function to get the modules for training from the parsed config.
     """
@@ -594,7 +623,7 @@ def get_modules_from_config(args):
         grid = load_mv_grid(args, train_dataset)
     elif args.dataset_type == "sdf":
         grid = load_sdf_grid(args)
-    nef = globals()[args.nef_type](grid=grid, **vars(args))
+    nef = load_nef(args, grid)
     tracer = globals()[args.tracer_type](**vars(args))
     pipeline = Pipeline(nef, tracer)
     pipeline = pipeline.to(device)

--- a/wisp/models/embedders/positional_embedder.py
+++ b/wisp/models/embedders/positional_embedder.py
@@ -62,22 +62,19 @@ class PositionalEmbedder(nn.Module):
             encoded = torch.cat([coords, encoded], dim=-1)
         return encoded
 
-def get_positional_embedder(frequencies, active, input_dim=3):
+def get_positional_embedder(frequencies, input_dim=3, include_input=True):
     """Utility function to get a positional encoding embedding.
 
     Args:
         frequencies (int): The number of frequencies used to define the PE:
             [2^0, 2^1, 2^2, ... 2^(frequencies - 1)].
-        active (bool): If false, will return the identity function.
         input_dim (int): The input coordinate dimension.
+        include_input (bool): If true, will concatenate the input coords.
 
     Returns:
         (nn.Module, int):
         - The embedding module
         - The output dimension of the embedding.
     """
-    if not active:
-        return nn.Identity(), input_dim
-    else:
-        encoder = PositionalEmbedder(frequencies, frequencies-1, input_dim=input_dim)
-        return encoder, encoder.out_dim
+    encoder = PositionalEmbedder(frequencies, frequencies-1, input_dim=input_dim, include_input=include_input)
+    return encoder, encoder.out_dim

--- a/wisp/models/grids/hash_grid.py
+++ b/wisp/models/grids/hash_grid.py
@@ -25,7 +25,7 @@ class HashGrid(BLASGrid):
     The occupancy state (e.g. BLAS, Bottom Level Acceleration Structure) is tracked separately from the feature
     volume, and relies on heuristics such as pruning for keeping it aligned with the feature structure.
     """
-    def __init__(self, 
+    def __init__(self,
         feature_dim        : int,
         base_lod           : int   = None,
         num_lods           : int   = 1,

--- a/wisp/renderer/core/renderers/radiance_pipeline_renderer.py
+++ b/wisp/renderer/core/renderers/radiance_pipeline_renderer.py
@@ -50,7 +50,7 @@ class NeuralRadianceFieldPackedRenderer(RayTracedRenderer):
 
     @classmethod
     def create_layers_painter(cls, nef: BaseNeuralField) -> Optional[Datalayers]:
-        if nef.grid_type in ('OctreeGrid', 'CodebookOctreeGrid', 'HashGrid'):
+        if nef.grid.__class__.__name__ in ('OctreeGrid', 'CodebookOctreeGrid', 'HashGrid'):
             return OctreeDatalayers()
         else:
             return None
@@ -111,13 +111,14 @@ class NeuralRadianceFieldPackedRenderer(RayTracedRenderer):
             return "None"
 
     def features_structure(self):
-        if self.nef.grid_type == "OctreeGrid":
+        grid_type = self.nef.grid.__class__.__name__
+        if grid_type == "OctreeGrid":
             return "Octree Grid"
-        elif self.nef.grid_type == "CodebookOctreeGrid":
+        elif grid_type == "CodebookOctreeGrid":
             return "Codebook Grid"
-        elif self.nef.grid_type == "TriplanarGrid":
+        elif grid_type == "TriplanarGrid":
             return "Triplanar Grid"
-        elif self.nef.grid_type == "HashGrid":
+        elif grid_type == "HashGrid":
             return "Hash Grid"
         else:
             return "Unknown"

--- a/wisp/renderer/core/renderers/sdf_pipeline_renderer.py
+++ b/wisp/renderer/core/renderers/sdf_pipeline_renderer.py
@@ -49,7 +49,7 @@ class NeuralSDFPackedRenderer(RayTracedRenderer):
 
     @classmethod
     def create_layers_painter(cls, nef: BaseNeuralField) -> Optional[Datalayers]:
-        if nef.grid_type in ('OctreeGrid', 'CodebookOctreeGrid', 'HashGrid'):
+        if nef.grid.__class__.__name__ in ('OctreeGrid', 'CodebookOctreeGrid', 'HashGrid'):
             return OctreeDatalayers()
         else:
             return None
@@ -106,13 +106,14 @@ class NeuralSDFPackedRenderer(RayTracedRenderer):
             return "None"
 
     def features_structure(self):
-        if self.nef.grid_type == "OctreeGrid":
+        grid_type = self.nef.grid.__class__.__name__
+        if grid_type == "OctreeGrid":
             return "Octree Grid"
-        elif self.nef.grid_type == "CodebookOctreeGrid":
+        elif grid_type == "CodebookOctreeGrid":
             return "Codebook Grid"
-        elif self.nef.grid_type == "TriplanarGrid":
+        elif grid_type == "TriplanarGrid":
             return "Triplanar Grid"
-        elif self.nef.grid_type == "HashGrid":
+        elif grid_type == "HashGrid":
             return "Hash Grid"
         else:
             return "Unknown"

--- a/wisp/tracers/packed_sdf_tracer.py
+++ b/wisp/tracers/packed_sdf_tracer.py
@@ -69,12 +69,9 @@ class PackedSDFTracer(BaseTracer):
         assert nef.grid is not None and "this tracer requires a grid"
         
         if lod_idx is None:
-            lod_idx = nef.num_lods-1
+            lod_idx = nef.grid.num_lods - 1
 
         timer = PerfTimer(activate=False)
-
-        res = float(2**(lod_idx+nef.base_lod))
-        #invres = 1.0 / res
         invres = 1.0
 
         # Trace SPC

--- a/wisp/trainers/multiview_trainer.py
+++ b/wisp/trainers/multiview_trainer.py
@@ -60,8 +60,8 @@ class MultiviewTrainer(BaseTrainer):
         
         if self.extra_args["random_lod"]:
             # Sample from a geometric distribution
-            population = [i for i in range(self.pipeline.nef.num_lods)]
-            weights = [2**i for i in range(self.pipeline.nef.num_lods)]
+            population = [i for i in range(self.pipeline.nef.grid.num_lods)]
+            weights = [2**i for i in range(self.pipeline.nef.grid.num_lods)]
             weights = [i/sum(weights) for i in weights]
             lod_idx = random.choices(population, weights)[0]
         else:
@@ -201,7 +201,7 @@ class MultiviewTrainer(BaseTrainer):
         if not os.path.exists(self.valid_log_dir):
             os.makedirs(self.valid_log_dir)
 
-        lods = list(range(self.pipeline.nef.num_lods))
+        lods = list(range(self.pipeline.nef.grid.num_lods))
         evaluation_results = self.evaluate_metrics(data["rays"], imgs, lods[-1], f"lod{lods[-1]}")
         record_dict.update(evaluation_results)
         if self.using_wandb:


### PR DESCRIPTION
This change refactors the neural fields: a simpler interface without kwargs, and less assumptions on the nef initialization.
The MR also simplifies some of the PE initialization / forward logic by introducing properties.
Some pos / view embedding paths which were unusable have now been restored.

Signed-off-by: operel <operel@nvidia.com>