### PR TITLE
Operel/mvdataset docker qol

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ trimesh>=3.0
 pandas
 tqdm
 Pillow
-scipy==1.5.2
+scipy>=1.7.2
 scikit-image
 scikit-learn
 six>=1.12.0

--- a/wisp/accelstructs/octree_as.py
+++ b/wisp/accelstructs/octree_as.py
@@ -21,14 +21,15 @@ class OctreeAS:
     """
     
     def __init__(self, octree):
-        """Initializes the acceleration structure from the topology of a sparse Structured Point Cloud (SPC).
-        Structured Point Clouds (SPC) is a sparse octree-based representation that is useful to
-        organize and efficiently pack 3D geometrically sparse information.
-        SPCs can be intuitively described as sparse voxel-grids, quantized point clouds, or voxelized point clouds.
+        """Initializes the acceleration structure from the topology of a sparse octree (Structured Point Cloud).
+        Structured Point Cloud (SPC) is a compact data structure for organizing and efficiently pack sparse 3D geometric
+        information.
+        Intuitively, SPCs can also be described as sparse voxel-grids, quantized point clouds, or
+        voxelized point clouds.
 
         Args:
             octree (torch.ByteTensor): SPC octree tensor, containing the acceleration structure topology.
-            For more details about this compact format, see:
+            For more details about this format, see:
              https://kaolin.readthedocs.io/en/latest/notes/spc_summary.html
         """
         self.octree = octree

--- a/wisp/accelstructs/octree_as.py
+++ b/wisp/accelstructs/octree_as.py
@@ -137,7 +137,7 @@ class OctreeAS:
             rays.origins, rays.dirs, level, return_depth=True, with_exit=with_exit)
         return ridx, pidx, depth
 
-    def _raymarch_voxel(self, rays, level=None, num_samples=64):
+    def _raymarch_voxel(self, rays, num_samples, level=None):
         """Samples points along the ray inside the SPC structure.
         Raymarch is achieved by intersecting the rays with the SPC cells.
         Then among the intersected cells, each cell is sampled num_samples times.
@@ -146,7 +146,8 @@ class OctreeAS:
         Args:
             rays (wisp.core.Rays): Ray origins and directions of shape [batch, 3].
             level (int) : The level of the octree to raytrace. If None, traces the highest level.
-            num_samples (int) : Number of samples per voxel
+            num_samples (int) : Number of samples generated per voxel. The total number of samples generated will
+                also depend on the number of cells a ray have intersected.
 
         Returns:
             (torch.LongTensor, torch.LongTensor, torch.FloatTensor,
@@ -187,7 +188,7 @@ class OctreeAS:
 
         return ridx, samples, depth_samples, deltas, boundary
 
-    def _raymarch_ray(self, rays, level=None, num_samples=1024):
+    def _raymarch_ray(self, rays, num_samples, level=None):
         """Samples points along the ray inside the SPC structure.
         Raymarch is achieved by sampling num_samples along each ray,
         and then filtering out samples which falls outside of occupied cells.
@@ -198,7 +199,8 @@ class OctreeAS:
         Args:
             rays (wisp.core.Rays): Ray origins and directions of shape [batch, 3].
             level (int) : The level of the octree to raytrace. If None, traces the highest level.
-            num_samples (int) : Number of samples per voxel
+            num_samples (int) : Number of samples generated per ray. The actual number of generated samples may be lower
+                due to samples intersecting empty cells.
 
         Returns:
             (torch.LongTensor, torch.LongTensor, torch.FloatTensor,
@@ -241,14 +243,12 @@ class OctreeAS:
 
         return ridx, samples, depth_samples, deltas, boundary
 
-    def raymarch(self, rays, num_samples, level=None, raymarch_type='voxel'):
+    def raymarch(self, rays, raymarch_type, num_samples, level=None):
         """Samples points along the ray inside the SPC structure.
         The exact algorithm employed for raymarching is determined by `raymarch_type`.
 
         Args:
             rays (wisp.core.Rays): Ray origins and directions of shape [batch, 3].
-            level (int) : The level of the octree to raytrace. If None, traces the highest level.
-            num_samples (int) : Number of samples per voxel
             raymarch_type (str): Sampling strategy to use for raymarch.
                 'voxel' - intersects the rays with the SPC cells. Then among the intersected cells, each cell
                     is sampled num_samples times.
@@ -256,6 +256,9 @@ class OctreeAS:
                 'ray' - samples num_samples along each ray, and then filters out samples which falls outside of occupied
                     cells.
                     In this scheme, num_hit_samples <= num_rays * num_samples
+            num_samples (int) : Number of samples generated per voxel or ray. The exact meaning of this arg depends on
+                the value of `raymarch_type`.
+            level (int) : The level of the octree to raytrace. If None, traces the highest level.
         
         Returns:
             (torch.LongTensor, torch.LongTensor, torch.FloatTensor,
@@ -277,16 +280,16 @@ class OctreeAS:
         # and or aliased. 
         if raymarch_type == 'voxel':
             ridx, samples, depth_samples, deltas, boundary = self._raymarch_voxel(rays=rays,
-                                                                                  level=level,
-                                                                                  num_samples=num_samples)
+                                                                                  num_samples=num_samples,
+                                                                                  level=level)
 
         # Samples points along the rays, and then uses the SPC object the filter out samples that don't hit
         # the SPC objects. This is a much more well-spaced-out sampling scheme and will work well for 
         # inside-looking-out scenes. The camera near and far planes will have to be adjusted carefully, however.
         elif raymarch_type == 'ray':
             ridx, samples, depth_samples, deltas, boundary = self._raymarch_ray(rays=rays,
-                                                                                level=level,
-                                                                                num_samples=num_samples)
+                                                                                num_samples=num_samples,
+                                                                                level=level)
 
         else:
             raise TypeError(f"Raymarch sampler type: {raymarch_type} is not supported by OctreeAS.")

--- a/wisp/config_parser.py
+++ b/wisp/config_parser.py
@@ -578,7 +578,6 @@ def load_dataset(args):
     if args.dataset_type == "multiview":
         transform = SampleRays(args.num_rays_sampled_per_img)
         train_dataset = MultiviewDataset(**vars(args), transform=transform)
-        train_dataset.init()
     elif args.dataset_type == "sdf":
         train_dataset = SDFDataset(args.sample_mode, args.num_samples,
                                    args.get_normals, args.sample_tex)

--- a/wisp/datasets/formats/nerf_standard.py
+++ b/wisp/datasets/formats/nerf_standard.py
@@ -104,14 +104,11 @@ def load_nerf_standard_data(root, split='train', bg_color='white', num_workers=-
 
     transform_dict = {}
 
-    train_only = False
-
     if mip is None:
         mip = 0
 
     if len(transforms) == 1:
         transform_dict['train'] = transforms[0]
-        train_only = True
     elif len(transforms) == 3:
         fnames = [os.path.basename(transform) for transform in transforms]
 
@@ -124,7 +121,8 @@ def load_nerf_standard_data(root, split='train', bg_color='white', num_workers=-
         raise RuntimeError("Unsupported number of splits, there should be ['test', 'train', 'val']")
 
     if split not in transform_dict:
-        raise RuntimeError(f"Split type ['{split}'] unsupported in the dataset provided")
+        log.info(f"WARNING: Split type ['{split}'] does not exist in the dataset. Falling back to train data.")
+        split = 'train'
 
     for key in transform_dict:
         with open(transform_dict[key], 'r') as f:

--- a/wisp/datasets/multiview_dataset.py
+++ b/wisp/datasets/multiview_dataset.py
@@ -55,16 +55,14 @@ class MultiviewDataset(Dataset):
         self.dataset_num_workers = dataset_num_workers
         self.transform = transform
 
+        self.coords = self.data = self.img_shape = self.num_imgs = self.coords_center = self.coords_scale = None
+        self.init()
+
     def init(self):
-        """Initializes the dataset.
-        """
-
-        # Get image tensors 
-        
+        """Initializes the dataset. """
+        # Get image tensors
         self.coords = None
-
         self.data = self.get_images()
-
         self.img_shape = self.data["imgs"].shape[1:3]
         self.num_imgs = self.data["imgs"].shape[0]
 
@@ -136,9 +134,11 @@ class MultiviewDataset(Dataset):
         ray_idx = torch.randperm(self.data["imgs"].shape[1])[:batch_size]
 
         out = {}
-        out['rays'] = Rays(origins=self.data["rays"].origins[idx, ray_idx],
-                dirs=self.data["rays"].dirs[idx, ray_idx],
-                dist_min=self.data["rays"].dist_min, dist_max=self.data["rays"].dist_max)
+        out['rays'] = Rays(
+            origins=self.data["rays"].origins[idx, ray_idx],
+            dirs=self.data["rays"].dirs[idx, ray_idx],
+            dist_min=self.data["rays"].dist_min,
+            dist_max=self.data["rays"].dist_max)
         out['imgs'] = self.data["imgs"][idx, ray_idx]
         
         return out

--- a/wisp/datasets/sdf_dataset.py
+++ b/wisp/datasets/sdf_dataset.py
@@ -18,7 +18,6 @@ import wisp.ops.spc as wisp_spc_ops
 class SDFDataset(Dataset):
     """Base class for single mesh datasets with points sampled only at a given octree sampling region.
     """
-
     def __init__(self, 
         sample_mode       : list = ['rand', 'rand', 'near', 'near', 'trace'],
         num_samples       : int = 100000,

--- a/wisp/models/grids/hash_grid.py
+++ b/wisp/models/grids/hash_grid.py
@@ -229,12 +229,12 @@ class HashGrid(BLASGrid):
         else:
             raise NotImplementedError
 
-    def raymarch(self, rays, num_samples, level=None, raymarch_type='voxel'):
+    def raymarch(self, rays, raymarch_type, num_samples, level=None):
         """Mostly a wrapper over OctreeAS.raymarch. See corresponding function for more details.
 
         Important detail: the OctreeGrid raymarch samples over the coarsest LOD where features are available.
         """
-        return self.blas.raymarch(rays, num_samples=num_samples, level=self.blas_level, raymarch_type=raymarch_type)
+        return self.blas.raymarch(rays, raymarch_type=raymarch_type, num_samples=num_samples, level=self.blas_level)
 
     def name(self) -> str:
         return "Hash Grid"

--- a/wisp/models/grids/octree_grid.py
+++ b/wisp/models/grids/octree_grid.py
@@ -390,12 +390,12 @@ class OctreeGrid(BLASGrid):
             
             return feats.reshape(*output_shape, self.feature_dim)
 
-    def raymarch(self, rays, num_samples, level=None, raymarch_type='voxel'):
+    def raymarch(self, rays, raymarch_type, num_samples, level=None):
         """Mostly a wrapper over OctreeAS.raymarch. See corresponding function for more details.
 
         Important detail: the OctreeGrid raymarch samples over the coarsest LOD where features are available.
         """
-        return self.blas.raymarch(rays, num_samples=num_samples, level=self.base_lod, raymarch_type=raymarch_type)
+        return self.blas.raymarch(rays, raymarch_type=raymarch_type, num_samples=num_samples, level=self.base_lod)
 
     def name(self) -> str:
         return "Octree Grid"

--- a/wisp/models/grids/triplanar_grid.py
+++ b/wisp/models/grids/triplanar_grid.py
@@ -133,12 +133,12 @@ class TriplanarGrid(BLASGrid):
 
         return fs
 
-    def raymarch(self, rays, num_samples, level=None, raymarch_type='voxel'):
+    def raymarch(self, rays, raymarch_type, num_samples, level=None):
         """Mostly a wrapper over OctreeAS.raymarch. See corresponding function for more details.
 
         Important detail: this is just used as an AABB tracer.
         """
-        return self.blas.raymarch(rays, num_samples=num_samples, level=0, raymarch_type=raymarch_type)
+        return self.blas.raymarch(rays, raymarch_type=raymarch_type, num_samples=num_samples, level=0)
 
     def raytrace(self, rays, level=None, with_exit=False):
         """By default, this function will use the equivalent BLAS function unless overridden for custom behaviour.

--- a/wisp/models/layers.py
+++ b/wisp/models/layers.py
@@ -95,7 +95,7 @@ def get_layer_class(layer_type):
     Retunrs:
         (nn.Module): The layer to be used for the decoder.
     """
-    if layer_type == 'none':
+    if layer_type == 'none' or layer_type=='linear':
         return nn.Linear
     elif layer_type == 'spectral_norm':
         return spectral_norm_

--- a/wisp/offline_renderer.py
+++ b/wisp/offline_renderer.py
@@ -99,7 +99,7 @@ class OfflineRenderer():
         render_res   : list = [1024, 720], # [w, h]
         camera_proj  : str  = 'persp', # one of ['persp', 'ortho']
         render_batch : int  = -1, # -1 for no batching
-        shading_mode : str  = 'matcap', # one of ['matcap', 'rb']
+        shading_mode : str  = 'rb', # one of ['matcap', 'rb']
         matcap_path  : str  = './data/matcap/Pearl.png', # set if shadming mode = matcap
         shadow       : bool = False, 
         ao           : bool = False, 


### PR DESCRIPTION
Quality of life improvements, these are all small local changes fit together:

* docker issue: bumpy spicy version to >=1.7.2 (user complaints on github)
* fix issue with validation splits missing in standard nerf (fix was in place and removed, restored here)
* ensure all dataset fields are declared in ctor
* basic decoder support for layer type ‘linear’ -> nn.Linear (previously was only called ‘none’ in config)
* offline renderer doesn’t assume matcap by default (which is specific to sdf pipelines right now)