### PR TITLE
Updated trainer lifecycle

### DIFF
--- a/wisp/renderer/gui/imgui/widget_optimization.py
+++ b/wisp/renderer/gui/imgui/widget_optimization.py
@@ -43,12 +43,12 @@ class WidgetOptimization(WidgetImgui):
                 state.optimization.running = False
                 state.renderer.background_tasks_paused = True
         else:
-            if curr_epoch > 0:
-                if imgui.button("Resume Training", width=button_width):
+            if curr_epoch == 1 and curr_iteration == 1:
+                if imgui.button("Start Training", width=button_width):
                     state.optimization.running = True
                     state.renderer.background_tasks_paused = False
             else:
-                if imgui.button("Start Training", width=button_width):
+                if imgui.button("Resume Training", width=button_width):
                     state.optimization.running = True
                     state.renderer.background_tasks_paused = False
 
@@ -57,7 +57,6 @@ class WidgetOptimization(WidgetImgui):
         formatted_time = str(datetime.timedelta(seconds=elapsed_time_seconds))
         formatted_time = formatted_time.split(".")[0]   # Remove microseconds
         imgui.text(f"Elapsed Time: {formatted_time}")
-
 
         if is_training_stopped:
             state.renderer.target_fps = None

--- a/wisp/tracers/base_tracer.py
+++ b/wisp/tracers/base_tracer.py
@@ -28,12 +28,11 @@ class BaseTracer(nn.Module, ABC):
     Tracers are generally expected to be differentiable (e.g. they're part of the training loop),
     though non-differentiable tracers are also allowed.
     """
-    
-    def __init__(self, **kwargs):
-        """Initializes the tracer class and sets the default arguments for trace.
 
+    def __init__(self):
+        """Initializes the tracer class and sets the default arguments for trace.
         This should be overrided and called if you want to pass custom defaults into the renderer.
-        If overrided, it should keep the arguments to `self.trace` in `self.` class variables.
+        If overridden, it should keep the arguments to `self.trace` in `self.` class variables.
         Then, if these variables exist and no function arguments are passed into forward,
         it will override them as the default.
         """
@@ -137,5 +136,4 @@ class BaseTracer(nn.Module, ABC):
                 default_arg = getattr(self, _arg, None)
                 if default_arg is not None:
                     input_args[_arg] = default_arg
-
         return self.trace(nef, requested_channels, requested_extra_channels, **input_args)

--- a/wisp/tracers/packed_rf_tracer.py
+++ b/wisp/tracers/packed_rf_tracer.py
@@ -44,12 +44,12 @@ class PackedRFTracer(BaseTracer):
                                sampling method in the future.
             bg_color (str): The background color to use.
         """
-        super().__init__(**kwargs)
+        super().__init__()
         self.raymarch_type = raymarch_type
         self.num_steps = num_steps
         self.step_size = step_size
         self.bg_color = bg_color
-    
+
     def get_supported_channels(self):
         """Returns the set of channel names this tracer may output.
         

--- a/wisp/tracers/packed_spc_tracer.py
+++ b/wisp/tracers/packed_spc_tracer.py
@@ -10,11 +10,14 @@ class PackedSPCTracer(BaseTracer):
     The logic of this tracer is straightforward and does not involve any neural operations:
     rays are intersected against the SPC points (cell centers).
     Each ray returns the color of the intersected cell, if such exists.
+
+    See: https://github.com/NVIDIAGameWorks/kaolin-wisp/tree/main/examples/spc_browser
+    See also: https://kaolin.readthedocs.io/en/latest/notes/spc_summary.html#spc
     """
 
     def __init__(self, **kwargs):
         """Set the default trace() arguments. """
-        super().__init__(**kwargs)
+        super().__init__()
 
     def get_supported_channels(self):
         """Returns the set of channel names this tracer may output.


### PR DESCRIPTION
Contains updates to the trainer lifecycle and better docs for tracers:
* After changing trainer to "steps by iterations" rather than by epochs, the gui step counter was bugged - this is fixed by this MR.
* Added pre_train / post_train functions which are useful for logging (i.e. shutting off the wandb connection)
* Some logging logic (mostly wandb) shifted to the trainer
* A fix to df.parquet which couldn't dump torch tensors
* Some extra args in trainer are handled more carefully to avoid crashes for the upcoming reformatted config parser

Signed-off-by: operel <operel@nvidia.com>