### PR TITLE
Revert neural fields properties

### DIFF
--- a/examples/latent_nerf/funny_nerf_hash.yaml
+++ b/examples/latent_nerf/funny_nerf_hash.yaml
@@ -42,7 +42,7 @@ trainer:
     model_format: 'full'
     valid_every: -1
     save_every: -1
-    render_every: -1
+    render_tb_every: -1
 
 grid:
     grid_type: 'HashGrid'

--- a/examples/latent_nerf/funny_nerf_octree.yaml
+++ b/examples/latent_nerf/funny_nerf_octree.yaml
@@ -41,7 +41,7 @@ trainer:
     model_format: 'full'
     valid_every: -1
     save_every: -1
-    render_every: -1
+    render_tb_every: -1
 
 grid:
     grid_type: 'OctreeGrid'

--- a/examples/spc_browser/widget_spc_selector.py
+++ b/examples/spc_browser/widget_spc_selector.py
@@ -34,7 +34,7 @@ class WidgetSPCSelector(WidgetImgui):
         features = {k: torch.from_numpy(v).to(device) for k, v in spc_fields.items() if k in ('colors', 'normals')}
 
         neural_field = SPCField(
-            octree=octree,
+            spc_octree=octree,
             features_dict=features,
             device=device
         )

--- a/wisp/models/nefs/neural_sdf.py
+++ b/wisp/models/nefs/neural_sdf.py
@@ -7,8 +7,6 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 import torch
-import logging as log
-
 from wisp.models.nefs import BaseNeuralField
 from wisp.models.embedders import get_positional_embedder
 from wisp.models.layers import get_layer_class
@@ -56,8 +54,6 @@ class NeuralSDF(BaseNeuralField):
         """
         if embedder_type == 'none':
             embedder, embed_dim = None, 0
-        elif embedder_type == 'identity':
-            embedder, embed_dim = torch.nn.Identity(), 0
         elif embedder_type == 'positional':
             embedder, embed_dim = get_positional_embedder(frequencies=frequencies, position_input=position_input)
         else:
@@ -67,7 +63,7 @@ class NeuralSDF(BaseNeuralField):
     def init_decoder(self, activation_type, layer_type, num_layers, hidden_dim):
         """Initializes the decoder object.
         """
-        decoder = BasicDecoder(input_dim=self.decoder_input_dim,
+        decoder = BasicDecoder(input_dim=self.decoder_input_dim(),
                                output_dim=1,
                                activation=get_activation_class(activation_type),
                                bias=True,
@@ -119,7 +115,6 @@ class NeuralSDF(BaseNeuralField):
             
         return dict(sdf=sdf)
 
-    @property
     def effective_feature_dim(self):
         if self.grid.multiscale_type == 'cat':
             effective_feature_dim = self.grid.feature_dim * self.grid.num_lods
@@ -127,9 +122,8 @@ class NeuralSDF(BaseNeuralField):
             effective_feature_dim = self.grid.feature_dim
         return effective_feature_dim
 
-    @property
     def decoder_input_dim(self):
-        input_dim = self.effective_feature_dim
+        input_dim = self.effective_feature_dim()
         if self.position_input:
             input_dim += self.pos_embed_dim
         return input_dim

--- a/wisp/models/nefs/spc_field.py
+++ b/wisp/models/nefs/spc_field.py
@@ -52,6 +52,7 @@ class SPCField(BaseNeuralField):
                 A flag which determines if this SPCField supports optimization or not.
                 Toggling optimization off allows for quick creation of SPCField objects.
         """
+        super().__init__()
         self.spc_octree = spc_octree
         self.features_dict = features_dict if features_dict is not None else dict()
         self.spc_device = device
@@ -62,7 +63,6 @@ class SPCField(BaseNeuralField):
         self.colors = None
         self.normals = None
         self.init_grid(spc_octree)
-        super().__init__(grid=self.grid, **kwargs)
 
     def init_grid(self, spc_octree):
         """ Uses the OctreeAS / OctreeGrid mechanism to quickly parse the SPC object into a Wisp Neural Field.


### PR DESCRIPTION
This changeset includes various bug fixes and debts from previous MRs (improve QOL):

1. Removing properties from neural fields, as torch modules don’t support them well
2. HashGrid: added from_resolutions ctor, and cleaned up the HashGrid **init** requiring redundant params
3. Fix reshape(-1) potential issue with empty tensors raymarch / tracer / hashinterp code
3. Temporarily remove ‘identity’ pos embedder type
4. Fix old config properties in funny_neural_field hash / octree
5. Fix for widget of SPCField which used old kwargs to call constructor

Signed-off-by: operel <operel@nvidia.com>