### PR TITLE
BaseAS interface

### DIFF
--- a/wisp/accelstructs/__init__.py
+++ b/wisp/accelstructs/__init__.py
@@ -6,5 +6,6 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
+from .base_as import BaseAS, ASQueryResults, ASRaytraceResults, ASRaymarchResults
 from .octree_as import OctreeAS
 from .aabb_as import AxisAlignedBBoxAS

--- a/wisp/accelstructs/base_as.py
+++ b/wisp/accelstructs/base_as.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# NVIDIA CORPORATION & AFFILIATES and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
+
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from dataclasses import dataclass
+import torch
+
+
+@dataclass
+class ASQueryResults:
+    """ A data holder for keeping the results of a single acceleration structure query() call.
+    A query receives a set of input coordinates and returns the cell indices of the acceleration structure where
+    the query coordinates fall.
+    """
+
+    pidx: torch.LongTensor
+    """ Holds the query results.
+    - If the query is invoked with `with_parents=False`, this field is a tensor of shape [num_coords],
+      containing indices of cells of the acceleration structure, where the query coordinates match.
+    - If the query is invoked with `with_parents=True`, this field is a tensor of shape [num_coords, level+1],
+      containing indices of the cells of the acceleration structure + the full parent hierarchy of each 
+      cell query result.
+    """
+
+
+@dataclass
+class ASRaytraceResults:
+    """ A data holder for keeping the results of a single acceleration structure raytrace() call.
+    A raytrace operation returns all intersections of the ray set with the acceleration structure cells.
+    Ray/cell intersections are also referred to in Kaolin & Wisp as "nuggets".
+    """
+
+    ridx: torch.LongTensor
+    """ A tensor containing the ray index of the ray that intersected each cell [num_nuggets]. 
+    (can be used to index into rays.origins and rays.dirs)
+    """
+
+    pidx: torch.LongTensor
+    """ Point indices into the cells of the acceleration structure, where the ray intersected a cell [num_nuggets] """
+
+    depth: torch.FloatTensor
+    """ Depths of each nugget, representing:
+      - The first intersection point of the ray with the cell (entry), and 
+      - Optionally also a second intersection point of the ray with the cell (exit).
+      A tensor of [num_intersections, 1 or 2]. 
+    """
+
+
+@dataclass
+class ASRaymarchResults:
+    """ A data holder for keeping the results of a single acceleration structure raymarching() call.
+    A raymarch operation advances the ray set within the acceleration structure and generates samples along the rays.
+    """
+
+    samples: torch.FloatTensor
+    """ Sample coordinates of shape [num_hit_samples, 3]"""
+
+    ridx: torch.LongTensor
+    """ A tensor containing the ray index of the ray that generated each sample [num_hit_samples]. 
+    Can be used to index into rays.origins and rays.dirs.
+    """
+
+    depth_samples: Optional[torch.FloatTensor]
+    """ Depths of each sample, a tensor of shape [num_hit_samples, 1] """
+
+    deltas: Optional[torch.FloatTensor]
+    """ Depth diffs between each sample and the previous one, a tensor of shape [num_hit_samples, 1] """
+
+    boundary: Optional[torch.BoolTensor]
+    """ Boundary tensor which marks the beginning of each variable-sized sample pack of shape [num_hit_samples].
+        That is: [True, False, False, False, True, False False] represents two rays of 4 and 3 samples respectively. 
+    """
+
+
+class BaseAS(ABC):
+    """
+    A base interface for all acceleration structures within Wisp.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def query(self, coords, level=None, with_parents=False) -> ASQueryResults:
+        """Returns the ``cell index`` corresponding to the sample coordinates
+        (indices of acceleration structure cells the query coords match).
+
+        Args:
+            coords (torch.FloatTensor) : 3D coordinates of shape [num_coords, 3].
+                Certain acceleration structures may require the coords to be normalized within some range.
+            level (int) : For acceleration structures which support multiple level-of-details,
+                level specifies the desired LOD to query. If None, queries the highest level.
+            with_parents (bool) : For acceleration structures which support multiple level-of-details,
+                If `with_parents=True`, this call will return the hierarchical parent indices as well.
+
+        Returns:
+            (ASQueryResults): A plain data object carrying the results of the results of the query operation,
+            containing the indices of cells matching the query coords.
+        """
+        raise NotImplementedError(f"{self.name} acceleration structure does not support the 'query' method.")
+
+    def raytrace(self, rays, level=None, with_exit=False) -> ASRaytraceResults:
+        """Traces rays against the SPC structure, returning all intersections along the ray with the SPC points
+        (SPC points are quantized, and can be interpreted as octree cell centers or corners).
+
+        Args:
+            rays (wisp.core.Rays): Ray origins and directions of shape [batch, 3].
+            level (int) : The level of the octree to raytrace. If None, traces the highest level.
+            with_exit (bool) : If True, also returns exit depth.
+
+        Returns:
+            (ASRaytraceResults): A plain data object carrying the results of the raytrace operation,
+             containing the indices of ray and cell intersections.
+        """
+        raise NotImplementedError(f"{self.name} acceleration structure does not support the 'raytrace' method.")
+
+    def raymarch(self, rays, *args, **kwargs) -> ASRaymarchResults:
+        """Samples points along the ray within the acceleration structure.
+        The exact algorithm used is under the responsibility of the acceleration structure.
+
+        Args:
+            rays (wisp.core.Rays): Ray origins and directions of shape [batch, 3].
+            *args, **kwargs: Optional args this specific acceleration structure requires for marching.
+        Returns:
+            (RaymarchResults): a plain data object carrying the results of raymarching,
+            containing samples generated by the ray marching.
+        """
+        raise NotImplementedError(f"{self.name} acceleration structure does not support the 'raymarch' method.")
+
+    @abstractmethod
+    def occupancy(self) -> List[int]:
+        """ Returns a list of length [LODs], where each element contains the number of cells occupied in that LOD """
+        raise NotImplementedError('All acceleration structures must implement the "occupancy" function.')
+
+    @abstractmethod
+    def capacity(self) -> List[int]:
+        """ Returns a list of length [LODs], where each element contains the total cell capacity in that LOD """
+        raise NotImplementedError('All acceleration structures must implement the "capacity" function.')
+
+    def name(self) -> str:
+        """
+        Returns:
+            (str) A BaseAS should be given a meaningful, human readable name.
+            By default, the class name is used.
+        """
+        return type(self).__name__

--- a/wisp/datasets/sdf_dataset.py
+++ b/wisp/datasets/sdf_dataset.py
@@ -131,7 +131,8 @@ class SDFDataset(Dataset):
 
         # Filter out points which do not belong to the narrowband
         self.pts_ = torch.cat(self.pts_, dim=0)
-        self.pidx = grid.query(self.pts_.cuda(), 0)
+        query_results = grid.query(self.pts_.cuda(), 0)
+        self.pidx = query_results.pidx
         self.pts_ = self.pts_[self.pidx>-1]
     
         # Sample distances and textures.

--- a/wisp/models/decoders/basic_decoders.py
+++ b/wisp/models/decoders/basic_decoders.py
@@ -64,7 +64,7 @@ class BasicDecoder(nn.Module):
             if i == 0: 
                 layers.append(self.layer(self.input_dim, self.hidden_dim, bias=self.bias))
             elif i in self.skip:
-                layers.append(self.layer(self.hidden_dim+input_dim, self.hidden_dim, bias=self.bias))
+                layers.append(self.layer(self.hidden_dim+self.input_dim, self.hidden_dim, bias=self.bias))
             else:
                 layers.append(self.layer(self.hidden_dim, self.hidden_dim, bias=self.bias))
         self.layers = nn.ModuleList(layers)

--- a/wisp/models/grids/blas_grid.py
+++ b/wisp/models/grids/blas_grid.py
@@ -7,7 +7,9 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 from abc import ABC, abstractmethod
+from typing import Set, Type
 import torch.nn as nn
+from wisp.accelstructs import BaseAS, ASQueryResults, ASRaytraceResults, ASRaymarchResults
 
 
 class BLASGrid(nn.Module, ABC):
@@ -24,17 +26,23 @@ class BLASGrid(nn.Module, ABC):
     Grids are usually employed as building blocks within neural fields (see: BaseNeuralField),
     possibly paired with decoders to form a neural field.
     """
-    def raymarch(self, *args, **kwargs):
+
+    def __init__(self, blas: BaseAS):
+        """ BLASGrids are generally assumed to contain bottom level acceleration structures. """
+        super().__init__()
+        self.blas = blas
+
+    def raymarch(self, *args, **kwargs) -> ASRaymarchResults:
         """By default, this function will use the equivalent BLAS function unless overridden for custom behaviour.
         """
         return self.blas.raymarch(*args, **kwargs)
 
-    def raytrace(self, *args, **kwargs):
+    def raytrace(self, *args, **kwargs) -> ASRaytraceResults:
         """By default, this function will use the equivalent BLAS function unless overridden for custom behaviour.
         """
         return self.blas.raytrace(*args, **kwargs)
 
-    def query(self, *args, **kwargs):
+    def query(self, *args, **kwargs) -> ASQueryResults:
         """By default, this function will use the equivalent BLAS function unless overridden for custom behaviour.
         """
         return self.blas.query(*args, **kwargs)
@@ -48,6 +56,10 @@ class BLASGrid(nn.Module, ABC):
         """
         raise NotImplementedError('A BLASGrid should implement the interpolation functionality according to '
                                   'the grid structure.')
+
+    def supported_blas(self) -> Set[Type[BaseAS]]:
+        """ Returns a set of bottom-level acceleration structures this grid type supports """
+        return set()
 
     def name(self) -> str:
         """

--- a/wisp/ops/sdf/metrics.py
+++ b/wisp/ops/sdf/metrics.py
@@ -47,7 +47,8 @@ def compute_sparse_sdf_iou(nef, coords, gts, lod_idx=0):
     if nef.grid is None:
         raise Exception(f"{nef.__class__.__name__} is incompatible with this function.")
     pred = torch.zeros([coords.shape[0], 1])
-    pidx = nef.grid.query(gts, lod_idx=lod_idx)
+    query_results = nef.grid.query(gts, lod_idx=lod_idx)
+    pidx = query_results.pidx
     mask = (pidx != -1)
 
     pred[mask] = nef(coords=gts[mask], pidx=pidx[mask], lod_idx=lod_idx, channels="sdf").cpu()

--- a/wisp/tracers/base_tracer.py
+++ b/wisp/tracers/base_tracer.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 from abc import abstractmethod, ABC
 import inspect
 
+
 class BaseTracer(nn.Module, ABC):
     """Base class for all tracers within Wisp.
     Tracers drive the mapping process which takes an input "Neural Field", and outputs a RenderBuffer of pixels.

--- a/wisp/tracers/packed_rf_tracer.py
+++ b/wisp/tracers/packed_rf_tracer.py
@@ -115,7 +115,11 @@ class PackedRFTracer(BaseTracer):
                                              level=nef.grid.active_lods[lod_idx],
                                              num_samples=num_steps,
                                              raymarch_type=raymarch_type)
-        ridx, samples, depths, deltas, boundary = raymarch_results
+        ridx = raymarch_results.ridx
+        samples = raymarch_results.samples
+        deltas = raymarch_results.deltas
+        boundary = raymarch_results.boundary
+        depths = raymarch_results.depth_samples
 
         # Get the indices of the ray tensor which correspond to hits
         ridx_hit = ridx[spc_render.mark_pack_boundaries(ridx.int())]

--- a/wisp/tracers/packed_sdf_tracer.py
+++ b/wisp/tracers/packed_sdf_tracer.py
@@ -81,7 +81,11 @@ class PackedSDFTracer(BaseTracer):
         invres = 1.0
 
         # Trace SPC
-        ridx, pidx, depth = nef.grid.raytrace(rays, nef.grid.active_lods[lod_idx], with_exit=True)
+        raytrace_results = nef.grid.raytrace(rays, nef.grid.active_lods[lod_idx], with_exit=True)
+        ridx = raytrace_results.ridx
+        pidx = raytrace_results.pidx
+        depth = raytrace_results.depth
+
         depth[...,0:1] += 1e-5
 
         first_hit = spc_render.mark_pack_boundaries(ridx)
@@ -97,7 +101,7 @@ class PackedSDFTracer(BaseTracer):
         t = depth[first_hit][...,0:1]
         x = torch.addcmul(nug_o, nug_d, t)
         dist = torch.zeros_like(t)
-        
+
         curr_pidx = pidx[first_hit].long()
         
         timer.check("initial")

--- a/wisp/tracers/packed_spc_tracer.py
+++ b/wisp/tracers/packed_spc_tracer.py
@@ -55,7 +55,10 @@ class PackedSPCTracer(BaseTracer):
         if lod_idx is None:
             lod_idx = nef.grid.blas.max_level
 
-        ridx, pidx, depths = nef.grid.blas.raytrace(rays, lod_idx, with_exit=False)
+        raytrace_results = nef.grid.blas.raytrace(rays, lod_idx, with_exit=False)
+        ridx = raytrace_results.ridx
+        pidx = raytrace_results.pidx
+        depths = raytrace_results.depth
 
         timer.check("Raytrace")
 


### PR DESCRIPTION
This pull request adds the `BaseAS` abstract, to unify the upcoming acceleration structures under a single interface.

Notably `raymarch` / `raytrace` / `query` now return dataclasses of results. This is desired because:

1. It allows to easily handle and pass around the various return values from these functions
2. In case some raymarch ops return other output formats in the future, we could more easily enforce it by querying the dataclass return type