### PR TITLE
Introduce WispModule and add support for most modules

### DIFF
--- a/wisp/accelstructs/base_as.py
+++ b/wisp/accelstructs/base_as.py
@@ -8,9 +8,10 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 import torch
+from wisp.core import WispModule
 
 
 @dataclass
@@ -79,7 +80,7 @@ class ASRaymarchResults:
     """
 
 
-class BaseAS(ABC):
+class BaseAS(WispModule, ABC):
     """
     A base interface for all acceleration structures within Wisp.
     """
@@ -143,10 +144,16 @@ class BaseAS(ABC):
         """ Returns a list of length [LODs], where each element contains the total cell capacity in that LOD """
         raise NotImplementedError('All acceleration structures must implement the "capacity" function.')
 
-    def name(self) -> str:
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+
+        Acceleration structures are encouraged to report:
+        - 'occupancy' - a list of length [LODs], where each element contains the number of cells occupied in that LOD
+        - 'capacity' - a list of length [LODs], where each element contains the total cell capacity in that LOD
         """
-        Returns:
-            (str) A BaseAS should be given a meaningful, human readable name.
-            By default, the class name is used.
-        """
-        return type(self).__name__
+        return {
+            '#Used Cells (LOD)': self.occupancy(),
+            '#Capacity (LOD)': self.capacity()
+        }

--- a/wisp/accelstructs/octree_as.py
+++ b/wisp/accelstructs/octree_as.py
@@ -323,7 +323,7 @@ class OctreeAS(BaseAS):
 
     def occupancy(self) -> List[int]:
         """ Returns a list of length [LODs], where each element contains the number of cells occupied in that LOD """
-        return self.pyramid[0, :-2].cpu().numpy()
+        return self.pyramid[0, :-2].cpu().numpy().tolist()
 
     def capacity(self) -> List[int]:
         """ Returns a list of length [LODs], where each element contains the total cell capacity in that LOD """

--- a/wisp/core/__init__.py
+++ b/wisp/core/__init__.py
@@ -13,3 +13,4 @@ from .channel_fn import *
 from .colors import *
 from .render_buffer import RenderBuffer
 from .transforms import ObjectTransform
+from .wisp_module import WispModule

--- a/wisp/core/wisp_module.py
+++ b/wisp/core/wisp_module.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# NVIDIA CORPORATION & AFFILIATES and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
+
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+import torch.nn as nn
+
+
+class WispModule(nn.Module, ABC):
+    """ A general interface for all Wisp building blocks, such as neural fields, grids and tracers.
+        WispModules should:
+        1. Provide their name & dictionary of public properties. That makes them compatible with systems like
+        logging & gui.
+        2. WispModules extend torch's nn.Module out of convenience.
+        Modules are not required however, to implement a forward() function.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def name(self) -> str:
+        """
+        Returns:
+            (str) A WispModule should be given a meaningful, human readable name.
+            By default, the class name is used.
+        """
+        return type(self).__name__
+
+    @abstractmethod
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        raise NotImplementedError('Wisp modules should implement the `public_properties` method')

--- a/wisp/models/decoders/basic_decoders.py
+++ b/wisp/models/decoders/basic_decoders.py
@@ -6,14 +6,14 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
-import numpy as np
+from typing import Dict, Any
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
+from wisp.core import WispModule
 
 from scipy.stats import ortho_group
 
-class BasicDecoder(nn.Module):
+class BasicDecoder(WispModule):
     """Super basic but super useful MLP class.
     """
     def __init__(self, 
@@ -117,6 +117,27 @@ class BasicDecoder(nn.Module):
             self.layers[i].weight = nn.Parameter(ms[i])
         m = get_weight(self.lout.weight)
         self.lout.weight = nn.Parameter(m)
+
+    def name(self) -> str:
+        """ A human readable name for the given wisp module. """
+        return "BasicDecoder"
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        return {
+            "Input Dim": self.input_dim,
+            "Hidden Dim": self.hidden_dim,
+            "Outpt Dim": self.output_dim,
+            "Num. Layers": self.num_layers,
+            "Layer Type": self.layer.__name__,
+            "Activation": self.activation.__name__,
+            "Bias": self.bias,
+            "Skip Connections": self.skip,
+        }
+
 
 def orthonormal(weight):
     """Initialize the layer as a random orthonormal matrix.

--- a/wisp/models/embedders/positional_embedder.py
+++ b/wisp/models/embedders/positional_embedder.py
@@ -6,10 +6,13 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
+from typing import Dict, Any
 import torch
 import torch.nn as nn
+from wisp.core import WispModule
 
-class PositionalEmbedder(nn.Module):
+
+class PositionalEmbedder(WispModule):
     """PyTorch implementation of regular positional embedding, as used in the original NeRF and Transformer papers.
     """
     def __init__(self, num_freq, max_freq_log2, log_sampling=True, include_input=True, input_dim=3):
@@ -61,6 +64,23 @@ class PositionalEmbedder(nn.Module):
         if self.include_input:
             encoded = torch.cat([coords, encoded], dim=-1)
         return encoded
+
+    def name(self) -> str:
+        """ A human readable name for the given wisp module. """
+        return "Positional Encoding"
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        return {
+            "Output Dim": self.out_dim,
+            "Num. Frequencies": self.num_freq,
+            "Max Frequency": f"2^{self.max_freq_log2}",
+            "Include Input": self.include_input
+        }
+
 
 def get_positional_embedder(frequencies, input_dim=3, include_input=True):
     """Utility function to get a positional encoding embedding.

--- a/wisp/models/grids/blas_grid.py
+++ b/wisp/models/grids/blas_grid.py
@@ -7,12 +7,12 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 from abc import ABC, abstractmethod
-from typing import Set, Type
-import torch.nn as nn
+from typing import Dict, Any, Set, Type
+from wisp.core import WispModule
 from wisp.accelstructs import BaseAS, ASQueryResults, ASRaytraceResults, ASRaymarchResults
 
 
-class BLASGrid(nn.Module, ABC):
+class BLASGrid(WispModule, ABC):
     """
     BLASGrids (commonly referred in documentation as simply "grids"), represent feature grids in Wisp.
     BLAS: "Bottom Level Acceleration Structure", to signify this structure is the backbone that captures
@@ -61,9 +61,13 @@ class BLASGrid(nn.Module, ABC):
         """ Returns a set of bottom-level acceleration structures this grid type supports """
         return set()
 
-    def name(self) -> str:
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+
+        BLASGrids are generally assumed to contain a bottom level acceleration structure.
         """
-        Returns:
-            (str) A BLASGrid should be given a meaningful, human readable name.
-        """
-        return type(self).__name__
+        return {
+            "Acceleration Structure": self.blas
+        }

--- a/wisp/models/grids/codebook_grid.py
+++ b/wisp/models/grids/codebook_grid.py
@@ -7,6 +7,7 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 from __future__ import annotations
+from typing import Dict, Any
 import logging as log
 import torch
 import torch.nn as nn
@@ -306,3 +307,14 @@ class CodebookOctreeGrid(OctreeGrid):
 
     def name(self) -> str:
         return "Codebook Grid"
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        parent_properties = super().public_properties()
+        properties = {
+            "Bitwidth": self.bitwidth
+        }
+        return {**parent_properties, **properties}

--- a/wisp/models/grids/hash_grid.py
+++ b/wisp/models/grids/hash_grid.py
@@ -7,7 +7,7 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 from __future__ import annotations
-from typing import Set, Type, List
+from typing import Dict, Set, Any, Type, List
 import torch
 import torch.nn as nn
 import numpy as np
@@ -237,3 +237,21 @@ class HashGrid(BLASGrid):
 
     def name(self) -> str:
         return "Hash Grid"
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        parent_properties = super().public_properties()
+        active_lods = None if self.active_lods is None or len(self.active_lods) == 0 else \
+            f'{min(self.active_lods)} - {max(self.active_lods)}'
+        properties = {
+            "Feature Dims": self.feature_dim,
+            "Total LODs": self.max_lod,
+            "Active feature LODs": active_lods,
+            "Interpolation": 'linear',
+            "Multiscale aggregation": self.multiscale_type,
+            "HashTable Size": f"2^{self.codebook_bitwidth}"
+        }
+        return {**parent_properties, **properties}

--- a/wisp/models/grids/octree_grid.py
+++ b/wisp/models/grids/octree_grid.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 import logging as log
-from typing import Set, Type
+from typing import Dict, Set, Any, Type
 import torch
 import torch.nn as nn
 import wisp.ops.spc as wisp_spc_ops
@@ -403,3 +403,18 @@ class OctreeGrid(BLASGrid):
 
     def name(self) -> str:
         return "Octree Grid"
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        parent_properties = super().public_properties()
+        properties = {
+            "Feature Dims": self.feature_dim,
+            "Total LODs": self.max_lod,
+            "Active feature LODs": [str(x) for x in self.active_lods],
+            "Interpolation": self.interpolation_type,
+            "Multiscale aggregation": self.multiscale_type
+        }
+        return {**parent_properties, **properties}

--- a/wisp/models/nefs/base_nef.py
+++ b/wisp/models/nefs/base_nef.py
@@ -6,12 +6,13 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
-import torch.nn as nn
 import inspect
 from abc import abstractmethod
+from typing import Dict, Any
+from wisp.core import WispModule
 
 
-class BaseNeuralField(nn.Module):
+class BaseNeuralField(WispModule):
     """The base class for all Neural Fields within Wisp.
     Neural Fields are defined as modules which take coordinates as input and output signals of some form.
     The term "Neural" is loosely used here to imply these modules are generally subject for optimization.
@@ -170,3 +171,10 @@ class BaseNeuralField(nn.Module):
             return [return_dict[channel] for channel in channels]
         else:
             return return_dict
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        return dict()

--- a/wisp/models/nefs/nerf.py
+++ b/wisp/models/nefs/nerf.py
@@ -7,6 +7,7 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 import torch
+from typing import Dict, Any
 from wisp.ops.geometric import sample_unif_sphere
 from wisp.models.nefs import BaseNeuralField
 from wisp.models.embedders import get_positional_embedder
@@ -244,3 +245,21 @@ class NeuralRadianceField(BaseNeuralField):
 
     def color_net_input_dim(self):
         return 16 + self.view_embed_dim
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        properties = {
+            "Grid": self.grid,
+            "Pos. Embedding": self.pos_embedder,
+            "View Embedding": self.view_embedder,
+            "Decoder (density)": self.decoder_density,
+            "Decoder (color)": self.decoder_color
+        }
+        if self.prune_density_decay is not None:
+            properties['Pruning Density Decay'] = self.prune_density_decay
+        if self.prune_min_density is not None:
+            properties['Pruning Min Density'] = self.prune_min_density
+        return properties

--- a/wisp/models/nefs/neural_sdf.py
+++ b/wisp/models/nefs/neural_sdf.py
@@ -7,6 +7,8 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 import torch
+from typing import Dict, Any
+
 from wisp.models.nefs import BaseNeuralField
 from wisp.models.embedders import get_positional_embedder
 from wisp.models.layers import get_layer_class
@@ -164,3 +166,15 @@ class NeuralSDF(BaseNeuralField):
         if self.position_input:
             input_dim += self.pos_embed_dim
         return input_dim
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        properties = {
+            "Grid": self.grid,
+            "Pos. Embedding": self.pos_embedder,
+            "Decoder (sdf)": self.decoder,
+        }
+        return properties

--- a/wisp/models/nefs/spc_field.py
+++ b/wisp/models/nefs/spc_field.py
@@ -1,3 +1,4 @@
+from typing import Dict, Any
 import numpy as np
 import torch
 from wisp.models.grids import OctreeGrid
@@ -133,3 +134,13 @@ class SPCField(BaseNeuralField):
 
         colors = self.colors[ridx_hit, :3].unsqueeze(1)
         return dict(rgb=colors)
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        properties = {
+            "Grid": self.grid,
+        }
+        return properties

--- a/wisp/renderer/core/renderers/radiance_pipeline_renderer.py
+++ b/wisp/renderer/core/renderers/radiance_pipeline_renderer.py
@@ -114,29 +114,9 @@ class NeuralRadianceFieldPackedRenderer(RayTracedRenderer):
     def dtype(self) -> torch.dtype:
         return torch.float32
 
-    @property
-    def model_matrix(self) -> torch.Tensor:
-        return torch.eye(4, device=self.device)
-
-    @property
-    def aabb(self) -> torch.Tensor:
-        # (center_x, center_y, center_z, width, height, depth)
-        return torch.tensor((0.0, 0.0, 0.0, 2.0, 2.0, 2.0), device=self.device)
-
-    def acceleration_structure(self) -> str:
-        """ Returns a human readable name of the bottom level acceleration structure used by this renderer """
-        if getattr(self.nef, 'grid') is None or getattr(self.nef.grid, 'blas') is None:
-            return "None"
-        elif hasattr(self.nef.grid.blas, 'name'):
-            return self.nef.grid.blas.name()
-        else:
-            return "Unknown"
-
-    def features_structure(self) -> str:
-        """ Returns a human readable name of the feature structure used by this renderer """
-        if getattr(self.nef, 'grid') is None:
-            return "None"
-        elif hasattr(self.nef.grid, 'name'):
-            return self.nef.grid.name()
-        else:
-            return "Unknown"
+    def name(self) -> str:
+        """
+        Returns:
+            (str) A a meaningful, human readable name representing the object this renderer paints.
+        """
+        return "Neural Radiance Field"

--- a/wisp/renderer/core/renderers/sdf_pipeline_renderer.py
+++ b/wisp/renderer/core/renderers/sdf_pipeline_renderer.py
@@ -108,29 +108,9 @@ class NeuralSDFPackedRenderer(RayTracedRenderer):
     def dtype(self) -> torch.dtype:
         return torch.float32
 
-    @property
-    def model_matrix(self) -> torch.Tensor:
-        return torch.eye(4, device=self.device)
-
-    @property
-    def aabb(self) -> torch.Tensor:
-        # (center_x, center_y, center_z, width, height, depth)
-        return torch.tensor((0.0, 0.0, 0.0, 2.0, 2.0, 2.0), device=self.device)
-
-    def acceleration_structure(self) -> str:
-        """ Returns a human readable name of the bottom level acceleration structure used by this renderer """
-        if getattr(self.nef, 'grid') is None or getattr(self.nef.grid, 'blas') is None:
-            return "None"
-        elif hasattr(self.nef.grid.blas, 'name'):
-            return self.nef.grid.blas.name()
-        else:
-            return "Unknown"
-
-    def features_structure(self) -> str:
-        """ Returns a human readable name of the feature structure used by this renderer """
-        if getattr(self.nef, 'grid') is None:
-            return "None"
-        elif hasattr(self.nef.grid, 'name'):
-            return self.nef.grid.name()
-        else:
-            return "Unknown"
+    def name(self) -> str:
+        """
+        Returns:
+            (str) A a meaningful, human readable name representing the object this renderer paints.
+        """
+        return "Neural Signed Distance Field"

--- a/wisp/renderer/core/renderers/spc_pipeline_renderer.py
+++ b/wisp/renderer/core/renderers/spc_pipeline_renderer.py
@@ -55,19 +55,9 @@ class SPCRenderer(RayTracedRenderer):
     def dtype(self) -> torch.dtype:
         return torch.float32
 
-    @property
-    def model_matrix(self) -> torch.Tensor:
-        return torch.eye(4, device=self.device)
-
-    @property
-    def aabb(self) -> torch.Tensor:
-        # (center_x, center_y, center_z, width, height, depth)
-        return torch.tensor((0.0, 0.0, 0.0, 2.0, 2.0, 2.0), device=self.device)
-
-    def acceleration_structure(self) -> str:
-        """ Returns a human readable name of the bottom level acceleration structure used by this renderer """
-        return "Octree"  # Assumes to always use OctreeAS
-
-    def features_structure(self) -> str:
-        """ Returns a human readable name of the feature structure used by this renderer """
-        return "Octree Grid"  # Assumes to always use OctreeGrid for storing features
+    def name(self) -> str:
+        """
+        Returns:
+            (str) A a meaningful, human readable name representing the object this renderer paints.
+        """
+        return "Structured Point Cloud"

--- a/wisp/tracers/base_tracer.py
+++ b/wisp/tracers/base_tracer.py
@@ -6,12 +6,14 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
+from typing import Dict, Any
 import torch.nn as nn
 from abc import abstractmethod, ABC
 import inspect
+from wisp.core import WispModule
 
 
-class BaseTracer(nn.Module, ABC):
+class BaseTracer(WispModule, ABC):
     """Base class for all tracers within Wisp.
     Tracers drive the mapping process which takes an input "Neural Field", and outputs a RenderBuffer of pixels.
     Different tracers may employ different algorithms for querying points, or tracing / marching rays through the
@@ -138,3 +140,10 @@ class BaseTracer(nn.Module, ABC):
                 if default_arg is not None:
                     input_args[_arg] = default_arg
         return self.trace(nef, requested_channels, requested_extra_channels, **input_args)
+
+    def public_properties(self) -> Dict[str, Any]:
+        """ Wisp modules expose their public properties in a dictionary.
+        The purpose of this method is to give an easy table of outwards facing attributes,
+        for the purpose of logging, gui apps, etc.
+        """
+        return dict()


### PR DESCRIPTION
This change set introduces the `WispModule` interface. All important base building blocks should subclass this interface: acceleration structures, grids (and their internal components like feature volume for triplane), decoders, position embedders, neural fields, bottom level renderers and so on.

The `WispModule` interface is fairly thin, it assumes a module:

1. Is a torch `nn.Module`
2. Knows how to return a dict of useful properties, this is useful for logging / gui purposes.
3. Optional: Knows how to return a human readable name (default is to take the class name, where this makes sense)

Signed-off-by: operel <operel@nvidia.com>