### PR TITLE
Default RayTracedRenderer

### DIFF
--- a/examples/latent_nerf/demo_app.py
+++ b/examples/latent_nerf/demo_app.py
@@ -73,8 +73,8 @@ class DemoApp(WispApp):
         """ -- wisp_state.renderer holds the interactive renderer configuration, let's explore it: -- """
 
         # Set the initial window dimensions
-        wisp_state.renderer.canvas_width = 1600
-        wisp_state.renderer.canvas_height = 1600
+        wisp_state.renderer.canvas_width = 1200
+        wisp_state.renderer.canvas_height = 800
 
         # Set which world grid planes should be displayed on the canvas.
         # Options: any combination of 'xy', 'xz', 'yz'. Use [] to turn off the grid.

--- a/wisp/renderer/core/api/__init__.py
+++ b/wisp/renderer/core/api/__init__.py
@@ -8,5 +8,6 @@
 
 from .renderers_factory import *
 from .base_renderer import *
+from .raytraced_renderer import *
 from .decorators import *
 from .scenegraph import *

--- a/wisp/renderer/core/api/decorators.py
+++ b/wisp/renderer/core/api/decorators.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 from typing import Type
 from wisp.models.nefs import BaseNeuralField
 from wisp.tracers import BaseTracer
-from wisp.renderer.core.api import BottomLevelRenderer, register_neural_field_type
+from wisp.renderer.core.api.base_renderer import BottomLevelRenderer
+from wisp.renderer.core.api.renderers_factory import register_neural_field_type
 
 
 def field_renderer(field_type: Type[BaseNeuralField], tracer_type: Type[BaseTracer]):

--- a/wisp/renderer/core/api/raytraced_renderer.py
+++ b/wisp/renderer/core/api/raytraced_renderer.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# NVIDIA CORPORATION & AFFILIATES and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
+
+from __future__ import annotations
+from typing import Optional, Dict
+import copy
+import torch
+from wisp.core import RenderBuffer, Rays, PrimitivesPack
+from wisp.models import Pipeline
+from wisp.models.nefs import BaseNeuralField
+from wisp.tracers import BaseTracer
+from wisp.renderer.core.api.base_renderer import BottomLevelRenderer, FramePayload
+from wisp.renderer.core.api.decorators import field_renderer
+from wisp.gfx.datalayers import Datalayers, OctreeDatalayers, AABBDatalayers
+from wisp.accelstructs import OctreeAS, AxisAlignedBBoxAS
+
+
+@field_renderer(BaseNeuralField, BaseTracer)
+class RayTracedRenderer(BottomLevelRenderer):
+    """ A default neural field renderers for all neural ray-based pipelines.
+        The renderer is registered with the general BaseNeuralField & BaseTracer
+        to make a default fallback for future combos of neural field / tracer which
+        don't implement a dedicated renderer.
+
+        Renderers represent "visualizable" objects in the interactive renderer system.
+        These include anything that could potentially be painted on the canvas, how to tune it, and what data-layers
+        it supports.
+        This specific renderer is concerned with neural objects which rely on ray tracing.
+
+        This class also serves as a convenience super-class for other renderers which shouldn't implement the entire
+        BottomLevelRenderer functionality from scratch.
+    """
+    def __init__(self, nef: BaseNeuralField, tracer: BaseTracer, batch_size=None, *args, **kwargs):
+        super().__init__(nef, *args, **kwargs)
+        self.nef = nef.eval()
+        self.tracer = tracer
+        self.layers_painter = self.create_layers_painter(self.nef)
+
+        self.batch_size = batch_size
+        self._data_layers = self.regenerate_data_layers()
+
+        # Per frame cached info
+        self.render_res_x = None
+        self.render_res_y = None
+        self.output_width = None
+        self.output_height = None
+        self.far_clipping = None
+        self.channels = None
+
+    @classmethod
+    def from_pipeline(cls, pipeline: Pipeline, **kwargs):
+        """ Builds a bottom level renderer from the building block of a pipeline. """
+        # Create a copy of the pipeline's tracer, with the same type and values
+        # This allows the renderer to modify the interactive tracer without affecting the pipeline
+        tracer = copy.deepcopy(pipeline.tracer)
+
+        # Pass the kwargs to the renderer also, in case it wants to further modify the tracer with them.
+        return cls(nef=pipeline.nef, tracer=tracer, **kwargs)
+
+    @classmethod
+    def create_layers_painter(cls, nef: BaseNeuralField) -> Optional[Datalayers]:
+        """ NeuralRadianceFieldPackedRenderer can draw datalayers showing the occupancy status.
+        These depend on the bottom level acceleration structure.
+        """
+        if not hasattr(nef.grid, 'blas'):
+            return None
+        elif isinstance(nef.grid.blas, AxisAlignedBBoxAS):
+            return AABBDatalayers()
+        elif isinstance(nef.grid.blas, OctreeAS):
+            return OctreeDatalayers()
+        else:
+            return None
+
+    def needs_refresh(self, payload: FramePayload, *args, **kwargs) -> bool:
+        """ Should the neural field be "refreshed" (meaning: retraced to a new RenderBuffer).
+            Retracing here generally means invoking calls that do not upload new data to the GPU.
+            The general logic cannot assume anything about the state of the neural field and therefore opts
+            to always refresh it.
+            WARNING: This is suboptimal for neural fields which take time to retrace.
+            Users are recommended to subclass and override this function by keeping track of the last state
+            and what fields changed since the last invocation.
+        """
+        return True
+
+    def needs_redraw(self) -> bool:
+        """ Returns if a full redrawing of the object should occur.
+            This includes regeneration of buffers that may get uploaded to the GPU, such as vectorial data layers.
+        """
+        if self.layers_painter is not None:
+            return self.layers_painter.needs_redraw(self.nef.grid.blas)
+        else:
+            return True
+
+    def regenerate_data_layers(self) -> Dict[str, PrimitivesPack]:
+        """ Regenarates the vectorial data layers depicting additional information about the object. """
+        if self.layers_painter is not None:
+            return self.layers_painter.regenerate_data_layers(self.nef.grid.blas)
+        else:
+            return dict()
+
+    def pre_render(self, payload: FramePayload, *args, **kwargs) -> None:
+        """ Actions which should take place before rendering:
+        Store information from payload, adjust resolution, and so forth.
+        """
+        super().pre_render(payload)
+        self.render_res_x = payload.render_res_x
+        self.render_res_y = payload.render_res_y
+        self.output_width = payload.camera.width
+        self.output_height = payload.camera.height
+        self.far_clipping = payload.camera.far
+        self.channels = payload.channels
+
+    def render(self, rays: Rays) -> RenderBuffer:
+        rb = RenderBuffer(hit=None)
+
+        # Feed as single batch
+        if self.batch_size is None:
+            rb = self.tracer(self.nef, rays=rays, channels=self.channels)
+        else:   # Apply in batches
+            for ray_batch in rays.split(self.batch_size):
+                rb += self.tracer(self.nef, rays=ray_batch, channels=self.channels)
+
+        # Rescale renderbuffer to original size
+        rb = rb.reshape(self.render_res_y, self.render_res_x, -1)
+        if self.render_res_x != self.output_width or self.render_res_y != self.output_height:
+            rb = rb.scale(size=(self.output_height, self.output_width))
+        return rb
+
+    def post_render(self) -> None:
+        """ Actions which should take place after rendering:
+        Store information for next frame.
+        """
+        pass
+
+    def acceleration_structure(self) -> str:
+        """ Returns a human readable name of the bottom level acceleration structure used by this renderer """
+        if getattr(self.nef, 'grid') is None or getattr(self.nef.grid, 'blas') is None:
+            return "None"
+        elif hasattr(self.nef.grid.blas, 'name'):
+            return self.nef.grid.blas.name()
+        else:
+            return "Unknown"
+
+    def features_structure(self) -> str:
+        """ Returns a human readable name of the feature structure used by this renderer """
+        if getattr(self.nef, 'grid') is None:
+            return "None"
+        elif hasattr(self.nef.grid, 'name'):
+            return self.nef.grid.name()
+        else:
+            return "Unknown"
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return torch.float32
+
+    @property
+    def device(self) -> torch.device:
+        return self.nef.device

--- a/wisp/renderer/core/api/renderers_factory.py
+++ b/wisp/renderer/core/api/renderers_factory.py
@@ -8,11 +8,13 @@
 
 from __future__ import annotations
 from collections import defaultdict, deque
-from typing import Type
+from typing import Type, TYPE_CHECKING
 from wisp.models import Pipeline
 from wisp.models.nefs import BaseNeuralField
 from wisp.tracers import BaseTracer
-from wisp.renderer.core.api.base_renderer import BottomLevelRenderer, RayTracedRenderer
+if TYPE_CHECKING:  # Prevent circular imports mess due to typed annotations
+    from wisp.renderer.core.api.base_renderer import BottomLevelRenderer
+    from wisp.renderer.core.api.raytraced_renderer import RayTracedRenderer
 
 # All renderers supported by the interactive renderer should be registered here
 # Registration can be quickly achieved via the @field_renderer decorator.

--- a/wisp/renderer/core/render_core.py
+++ b/wisp/renderer/core/render_core.py
@@ -17,8 +17,7 @@ from kaolin.render.camera import Camera, PinholeIntrinsics, OrthographicIntrinsi
 from wisp.framework import WispState, BottomLevelRendererState
 from wisp.core import RenderBuffer, Rays, PrimitivesPack, create_default_channel, ObjectTransform
 from wisp.ops.raygen import generate_pinhole_rays, generate_ortho_rays, generate_centered_pixel_coords
-from wisp.renderer.core.api import BottomLevelRenderer, RayTracedRenderer, create_neural_field_renderer
-from wisp.renderer.core.api import FramePayload
+from wisp.renderer.core.api import BottomLevelRenderer, RayTracedRenderer, FramePayload, create_neural_field_renderer
 from wisp.gfx.datalayers import CameraDatalayers
 
 

--- a/wisp/renderer/core/renderers/radiance_pipeline_renderer.py
+++ b/wisp/renderer/core/renderers/radiance_pipeline_renderer.py
@@ -7,14 +7,10 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 from __future__ import annotations
-from typing import Optional, Dict
-import torch
 from wisp.core import RenderBuffer, Rays, PrimitivesPack
 from wisp.renderer.core.api import RayTracedRenderer, FramePayload, field_renderer
 from wisp.models.nefs.nerf import NeuralRadianceField, BaseNeuralField
 from wisp.tracers import PackedRFTracer
-from wisp.accelstructs import OctreeAS, AxisAlignedBBoxAS
-from wisp.gfx.datalayers import Datalayers, OctreeDatalayers, AABBDatalayers
 
 
 @field_renderer(BaseNeuralField, PackedRFTracer)
@@ -22,12 +18,14 @@ class NeuralRadianceFieldPackedRenderer(RayTracedRenderer):
     """ A neural field renderers for pipelines of NeuralRadianceField + PackedRFTracer.
         The renderer is registered with the general BaseNeuralField to make a default fallback for future neural field
         subclasses which use the PackedRFTracer and don't implement a dedicated renderer.
+
+        NeuralRadianceFieldPackedRenderer is capable of reducing the tracer settings to lower quality when interactive
+        mode is on.
     """
 
-    def __init__(self, nef: NeuralRadianceField, tracer_type=None, batch_size=2**14, num_steps=None,
-                 min_dis=None, raymarch_type=None, *args, **kwargs):
-        super().__init__(nef, *args, **kwargs)
-        self.batch_size = batch_size
+    def __init__(self, nef: NeuralRadianceField, tracer: PackedRFTracer, batch_size=2**14, num_steps=None,
+                 raymarch_type=None, *args, **kwargs):
+        super().__init__(nef, tracer, batch_size, *args, **kwargs)
         if num_steps is None:
             num_steps = 2
         self.num_steps = num_steps
@@ -37,68 +35,30 @@ class NeuralRadianceFieldPackedRenderer(RayTracedRenderer):
         self.raymarch_type = raymarch_type
         self.bg_color = 'black'
 
-        self.tracer = tracer_type() if tracer_type is not None else PackedRFTracer()
-        self.render_res_x = None
-        self.render_res_y = None
-        self.output_width = None
-        self.output_height = None
-        self.far_clipping = None
-        self.channels = None
         self._last_state = dict()
-
-        self._data_layers = self.regenerate_data_layers()
-
-    @classmethod
-    def create_layers_painter(cls, nef: BaseNeuralField) -> Optional[Datalayers]:
-        """ NeuralRadianceFieldPackedRenderer can draw datalayers showing the occupancy status.
-        These depend on the bottom level acceleration structure.
-        """
-        if not hasattr(nef.grid, 'blas'):
-            return None
-        elif isinstance(nef.grid.blas, AxisAlignedBBoxAS):
-            return AABBDatalayers()
-        elif isinstance(nef.grid.blas, OctreeAS):
-            return OctreeDatalayers()
-        else:
-            return None
-
-    def needs_redraw(self) -> bool:
-        if self.layers_painter is not None:
-            return self.layers_painter.needs_redraw(self.nef.grid.blas)
-        else:
-            return True
-
-    def regenerate_data_layers(self) -> Dict[str, PrimitivesPack]:
-        if self.layers_painter is not None:
-            return self.layers_painter.regenerate_data_layers(self.nef.grid.blas)
-        else:
-            return dict()
 
     def pre_render(self, payload: FramePayload, *args, **kwargs) -> None:
         super().pre_render(payload)
-        self.render_res_x = payload.render_res_x
-        self.render_res_y = payload.render_res_y
-        self.output_width = payload.camera.width
-        self.output_height = payload.camera.height
-        self.far_clipping = payload.camera.far
         self.bg_color = 'black' if payload.clear_color == (0.0, 0.0, 0.0) else 'white'
         if payload.interactive_mode:
             self.tracer.num_steps = self.num_steps_movement
         else:
             self.tracer.num_steps = self.num_steps
-        self.channels = payload.channels
 
     def needs_refresh(self, payload: FramePayload, *args, **kwargs) -> bool:
         return self._last_state.get('num_steps', 0) < self.num_steps or \
                self._last_state.get('channels') != self.channels
 
-    def render(self, rays: Optional[Rays] = None) -> RenderBuffer:
+    def render(self, rays: Rays) -> RenderBuffer:
         rb = RenderBuffer(hit=None)
         for ray_batch in rays.split(self.batch_size):
-            # TODO(ttakikawa): Add a way to control the LOD in the GUI
-            rb += self.tracer(self.nef, channels=self.channels,
-                              rays=ray_batch, lod_idx=None, raymarch_type=self.raymarch_type,
-                              num_steps=self.num_steps, bg_color=self.bg_color)
+            rb += self.tracer(self.nef,
+                              rays=ray_batch,
+                              channels=self.channels,
+                              lod_idx=None,  # TODO(ttakikawa): Add a way to control the LOD in the GUI
+                              raymarch_type=self.raymarch_type,
+                              num_steps=self.num_steps,
+                              bg_color=self.bg_color)
 
         # Rescale renderbuffer to original size
         rb = rb.reshape(self.render_res_y, self.render_res_x, -1)
@@ -109,14 +69,3 @@ class NeuralRadianceFieldPackedRenderer(RayTracedRenderer):
     def post_render(self) -> None:
         self._last_state['num_steps'] = self.tracer.num_steps
         self._last_state['channels'] = self.channels
-
-    @property
-    def dtype(self) -> torch.dtype:
-        return torch.float32
-
-    def name(self) -> str:
-        """
-        Returns:
-            (str) A a meaningful, human readable name representing the object this renderer paints.
-        """
-        return "Neural Radiance Field"

--- a/wisp/renderer/core/renderers/spc_pipeline_renderer.py
+++ b/wisp/renderer/core/renderers/spc_pipeline_renderer.py
@@ -1,63 +1,38 @@
-import torch
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# NVIDIA CORPORATION & AFFILIATES and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
+
+from __future__ import annotations
 from typing import Optional
-from wisp.core import RenderBuffer, Rays
-from wisp.accelstructs import OctreeAS
 from wisp.models.nefs import SPCField
 from wisp.tracers import PackedSPCTracer
 from wisp.gfx.datalayers import Datalayers, OctreeDatalayers
-from wisp.renderer.core.api import field_renderer, RayTracedRenderer, FramePayload
+from wisp.renderer.core.api import RayTracedRenderer, field_renderer, FramePayload
 
 
 @field_renderer(SPCField, PackedSPCTracer)
 class SPCRenderer(RayTracedRenderer):
     """ A renderer for SPC objects, used with pipelines of SPCField + PackedSPCTracer. """
 
-    def __init__(self, nef: SPCField, batch_size=4000, *args, **kwargs):
-        super().__init__(nef, *args, **kwargs)
-
-        self.tracer = PackedSPCTracer()
-        self.batch_size = batch_size
-        self.render_res_x = None
-        self.render_res_y = None
-        self.output_width = None
-        self.output_height = None
-        self._data_layers = self.regenerate_data_layers()
-        self.channels = None
+    def __init__(self, nef: SPCField, tracer: PackedSPCTracer, batch_size=4000, *args, **kwargs):
+        super().__init__(nef, tracer, batch_size, *args, **kwargs)
 
     @classmethod
     def create_layers_painter(cls, nef: SPCField) -> Optional[Datalayers]:
         return OctreeDatalayers()   # Always assume an octree grid object exists for this field
 
-    def pre_render(self, payload: FramePayload, *args, **kwargs) -> None:
-        super().pre_render(payload)
-        self.render_res_x = payload.render_res_x
-        self.render_res_y = payload.render_res_y
-        self.output_width = payload.camera.width
-        self.output_height = payload.camera.height
-        self.channels = payload.channels
-
     def needs_refresh(self, payload: FramePayload, *args, **kwargs) -> bool:
         """ SPC never requires a refresh due to internal state changes """
         return False
 
-    def render(self, rays: Optional[Rays] = None) -> RenderBuffer:
-        rb = RenderBuffer(hit=None)
-        for ray_batch in rays.split(self.batch_size):
-            rb += self.tracer(self.nef, channels=self.channels, rays=ray_batch, lod_idx=None)
+    def acceleration_structure(self) -> str:
+        """ Returns a human readable name of the bottom level acceleration structure used by this renderer """
+        return "Octree"  # Assumes to always use OctreeAS
 
-        # Rescale renderbuffer to original size
-        rb = rb.reshape(self.render_res_y, self.render_res_x, -1)
-        if self.render_res_x != self.output_width or self.render_res_y != self.output_height:
-            rb = rb.scale(size=(self.output_height, self.output_width))
-        return rb
-
-    @property
-    def dtype(self) -> torch.dtype:
-        return torch.float32
-
-    def name(self) -> str:
-        """
-        Returns:
-            (str) A a meaningful, human readable name representing the object this renderer paints.
-        """
-        return "Structured Point Cloud"
+    def features_structure(self) -> str:
+        """ Returns a human readable name of the feature structure used by this renderer """
+        return "Octree Grid"  # Assumes to always use OctreeGrid for storing features

--- a/wisp/tracers/packed_rf_tracer.py
+++ b/wisp/tracers/packed_rf_tracer.py
@@ -65,7 +65,7 @@ class PackedRFTracer(BaseTracer):
         """
         return {"rgb", "density"}
 
-    def trace(self, nef, channels, extra_channels, rays,
+    def trace(self, nef, rays, channels, extra_channels,
               lod_idx=None, raymarch_type='voxel', num_steps=64, step_size=1.0, bg_color='white'):
         """Trace the rays against the neural field.
 

--- a/wisp/tracers/packed_sdf_tracer.py
+++ b/wisp/tracers/packed_sdf_tracer.py
@@ -51,18 +51,18 @@ class PackedSDFTracer(BaseTracer):
         """
         return {"sdf"}
 
-    def trace(self, nef, channels, extra_channels, rays, lod_idx=None, num_steps=64,
+    def trace(self, nef, rays, channels, extra_channels, lod_idx=None, num_steps=64,
               step_size=1.0, min_dis=1e-4):
         """Trace the rays against the neural field.
 
         Args:
             nef (nn.Module): A neural field that uses a grid class.
-            channels (set): The set of requested channels. The trace method can return channels that 
+            rays (wisp.core.Rays): Ray origins and directions of shape [N, 3]
+            channels (set): The set of requested channels. The trace method can return channels that
                             were not requested since those channels often had to be computed anyways.
             extra_channels (set): If there are any extra channels requested, this tracer will by default
                                   query those extra channels at surface intersection points.
-            rays (wisp.core.Rays): Ray origins and directions of shape [N, 3]
-            lod_idx (int): LOD index to render at. 
+            lod_idx (int): LOD index to render at.
             num_steps (int): The number of steps to use for sphere tracing.
             step_size (float): The multiplier for the sphere tracing steps. 
                                Use a value <1.0 for conservative tracing.

--- a/wisp/tracers/packed_spc_tracer.py
+++ b/wisp/tracers/packed_spc_tracer.py
@@ -35,14 +35,14 @@ class PackedSPCTracer(BaseTracer):
         """
         return {"rgb"}
 
-    def trace(self, nef, channels, extra_channels, rays, lod_idx=None):
+    def trace(self, nef, rays, channels, extra_channels, lod_idx=None):
         """Trace the rays against the neural field.
 
         Args:
             nef (nn.Module): A neural field that uses a grid class.
+            rays (wisp.core.Rays): Ray origins and directions of shape [N, 3]
             channels (set): The set of requested channels. The trace method can return channels that
                             were not requested since those channels often had to be computed anyways.
-            rays (wisp.core.Rays): Ray origins and directions of shape [N, 3]
             lod_idx (int): LOD index to render at.
 
         Returns:

--- a/wisp/trainers/base_trainer.py
+++ b/wisp/trainers/base_trainer.py
@@ -16,6 +16,7 @@ from torch.utils.data import DataLoader
 from wisp.offline_renderer import OfflineRenderer
 from wisp.framework import WispState, BottomLevelRendererState
 from wisp.datasets import default_collate
+from wisp.renderer.core.api import add_to_scene_graph
 
 import wandb
 import numpy as np
@@ -138,7 +139,11 @@ class BaseTrainer(ABC):
         self.batch_size = batch_size
         self.exp_name = exp_name if exp_name else "unnamed_experiment"
 
-        self.scene_state.graph.neural_pipelines[self.exp_name] = self.pipeline
+        # Add object to scene graph: if interactive mode is on, this will make sure the visualizer can display it.
+        # batch_size is an optional setup arg here which hints the visualizer how many rays can be processed at once
+        # (e.g. this is the pipeline's batch_size used for inference time)
+        add_to_scene_graph(state=self.scene_state, name=self.exp_name, obj=self.pipeline, batch_size=2**14)
+        # Update optimization state about the current train set used
         self.scene_state.optimization.train_data.append(dataset)
 
         if hasattr(self.dataset, "data"):


### PR DESCRIPTION
In Wisp, objects displayed on the interactive visualizer canvas are represented by `BottomLevelRenderer` instances.
For neural fields, this means a `BottomLevelRenderer` represents a pair of neural field & tracer.

`NeuralRadianceFieldPackedRenderer`, for example, registers `@field_renderer(BaseNeuralField, PackedRFTracer)`, so any neural field traceable by `PackedRFTracer` is supported by it.
Before this PR, adding a new subclass of `BaseTracer` (not a subclass of `PackedRFTracer`) would mean one had to also implement a corresponding `BottomLevelRenderer` to display that object.

With this PR, any `BaseNeuralField` + `BaseTracer` subclasses combo that did not register a `@field_renderer` would automatically use the default renderer:`RayTracedRenderer`.

Note that specialized Renderers may still be required for:
1. Defining optimal conditions of when the object should be refreshed / redrawn
2. Painting additional data layers
3. Defining custom behavior for interactive mode / pre-render / post-render. 

Signed-off-by: operel <operel@nvidia.com>