### PR TITLE
Performance optimization for Hashgrid and RFTracer

### DIFF
--- a/wisp/csrc/ops/hashgrid_interpolate.h
+++ b/wisp/csrc/ops/hashgrid_interpolate.h
@@ -17,16 +17,17 @@ namespace wisp {
 
 at::Tensor hashgrid_interpolate_cuda(
     at::Tensor coords,
-    std::vector<at::Tensor> codebook,
+    at::Tensor codebook,
+    at::Tensor codebook_first_idx,
     std::vector<int32_t> resolution,
     int32_t codebook_bitwidth);
 
-std::vector<at::Tensor> hashgrid_interpolate_backward_cuda(
+at::Tensor hashgrid_interpolate_backward_cuda(
     at::Tensor coords,
     at::Tensor grad_output,
-    std::vector<at::Tensor> codebook,
+    at::Tensor codebook,
+    at::Tensor codebook_first_idx,
     std::vector<int32_t> resolution,
-    std::vector<int32_t> codebook_shapes,
     int32_t codebook_bitwidth,
     int32_t feature_dim,
     bool require_grad_coords);

--- a/wisp/tracers/packed_rf_tracer.py
+++ b/wisp/tracers/packed_rf_tracer.py
@@ -122,7 +122,7 @@ class PackedRFTracer(BaseTracer):
         depths = raymarch_results.depth_samples
 
         # Get the indices of the ray tensor which correspond to hits
-        ridx_hit = ridx[spc_render.mark_pack_boundaries(ridx.int())]
+        ridx_hit = ridx[boundary]
         # Compute the color and density for each ray and their samples
         hit_ray_d = rays.dirs.index_select(0, ridx)
 

--- a/wisp/trainers/multiview_trainer.py
+++ b/wisp/trainers/multiview_trainer.py
@@ -57,7 +57,8 @@ class MultiviewTrainer(BaseTrainer):
         rays = data['rays'].to(self.device).squeeze(0)
         img_gts = data['rgb'].to(self.device).squeeze(0)
 
-        self.optimizer.zero_grad()
+        self.optimizer.zero_grad(set_to_none=True)
+            
         loss = 0
         
         if self.extra_args["random_lod"]:


### PR DESCRIPTION
Performance optimization PR:

- Use packed representation of hashgrid codebook to reduce overhead of casting to FP16 in AMP training
- Precompute masks for point filtering to reduce CPU <-> GPU synchronization count
- Optimizer sets grads to None because it is faster than zeroing grads