### PR TITLE
Fix "Start Training" button label

### DIFF
--- a/wisp/renderer/gui/imgui/widget_optimization.py
+++ b/wisp/renderer/gui/imgui/widget_optimization.py
@@ -43,7 +43,7 @@ class WidgetOptimization(WidgetImgui):
                 state.optimization.running = False
                 state.renderer.background_tasks_paused = True
         else:
-            if curr_epoch == 1 and curr_iteration == 1:
+            if curr_epoch == 1 and curr_iteration == 0:
                 if imgui.button("Start Training", width=button_width):
                     state.optimization.running = True
                     state.renderer.background_tasks_paused = False


### PR DESCRIPTION
Fixes the "Start Button" in `widget_optimization` to show the correct label when loading the app window (introduced after a recent fix to the iterations counter in trainer).

Signed-off-by: operel <operel@nvidia.com>