### PR TITLE
 OpenGL bug fix: load glumpy with set version

### DIFF
--- a/wisp/framework/state.py
+++ b/wisp/framework/state.py
@@ -114,6 +114,15 @@ class InteractiveRendererState:
         'none' - No inherent antialising mode will be activated.
     """
 
+    gl_version: str = "GL 3.3"
+    """ Wisp applications rely on glumpy + OpenGL to render specific features and blit content to the window.
+    This setting configures glumpy to load with a specific OpenGL backend.
+    OpenGL 3.3 is widely supported and is therefore assumed to be the default.
+    Users are free to bump this version to a higher number in case more advanced OpenGL capabilities are required.
+    Format: (api major.minor. profile)
+    For example: "GL 3.3 core"  
+    """
+
     reference_grids: List[str] = field(default_factory=list)
     """ List of world grids to use as reference planes, for both rendering and some camera controllers.
         Choices: Any combination of the values: 'xy', 'xz', 'yz'. An empty list will turn off the grid.

--- a/wisp/renderer/app/wisp_app.py
+++ b/wisp/renderer/app/wisp_app.py
@@ -82,7 +82,7 @@ class WispApp(ABC):
 
         # Create main app window & initialize GL context
         # glumpy with a specialized glfw backend takes care of that (backend is imgui integration aware)
-        window = self._create_window(self.width, self.height, window_name)
+        window = self._create_window(self.width, self.height, window_name, gl_version=wisp_state.renderer.gl_version)
         self.register_io_mappings()
 
         # Initialize gui, assumes the window is managed by glumpy with glfw
@@ -242,10 +242,9 @@ class WispApp(ABC):
         """
         app.run()   # App clock should always run as frequently as possible (background tasks should not be limited)
 
-    def _create_window(self, width, height, window_name):
+    def _create_window(self, width, height, window_name, gl_version):
         # Currently assume glfw backend due to integration with imgui
-        app.use("glfw_imgui")
-
+        app.use(f"glfw_imgui ({gl_version})")
         win_config = app.configuration.Configuration()
         if self.wisp_state.renderer.antialiasing == 'msaa_4x':
             win_config.samples = 4


### PR DESCRIPTION
Explicitly sets the OpenGL version that glumpy's glfw+imgui backend uses.
The OpenGL version and profile are now also configurable via the `WispState`.

This should fix various OpenGL errors users have reported, such as `invalid operation` for `glVertexAttribPointer` and `glGetUniformLocation`.

Signed-off-by: operel <operel@nvidia.com>