### PR TITLE
 Fix default bottom level renderers args from tracers

### DIFF
--- a/app/nglod/configs/nglod_base.yaml
+++ b/app/nglod/configs/nglod_base.yaml
@@ -38,7 +38,7 @@ trainer:
 
 # Sphere Tracer is employed during inference only
 tracer:
-    num_steps: 128
+    num_steps: 32   # Usual range should be within [32, 128] according to model complexity (increasing may reduce FPS).
     step_size: 0.8
 
 # NOTE: These are OfflineRenderer definitions, used for validation. See WispState for interactive app definitions.

--- a/wisp/renderer/core/renderers/sdf_pipeline_renderer.py
+++ b/wisp/renderer/core/renderers/sdf_pipeline_renderer.py
@@ -19,20 +19,45 @@ class NeuralSDFPackedRenderer(RayTracedRenderer):
         subclasses which use the PackedSDFTracer and don't implement a dedicated renderer.
     """
 
-    def __init__(self, nef: NeuralSDF, tracer: PackedSDFTracer, samples_per_ray=32, *args, **kwargs):
+    def __init__(self, nef: NeuralSDF, tracer: PackedSDFTracer, num_steps=None, step_size=None, min_dis=None,
+                 *args, **kwargs):
+        """
+        Construct a new neural signed distance field from the nef + tracer pipeline.
+        By default, tracing will use the tracer args, unless specific values are specified for overriding those
+        defaults.
+
+        Args:
+            nef (BaseNeuralField): Neural field component of the pipeline. The neural field is expected to be coordinate
+             based.
+            tracer (PackedSDFTracer): Tracer component of the pipeline, assumed to trace signed distance fields.
+            num_steps (int): Number of steps used for sphere tracing.
+                By default, the tracer num_steps will be used. Specify an explicit value to override.
+            step_size (float): The multiplier for the sphere tracing steps. Use a value <1.0 for conservative tracing.
+                By default, the tracer step_size will be used. Specify an explicit value to override.
+            min_dis (float): The termination distance for sphere tracing.
+                By default, the tracer min_dis will be used. Specify an explicit value to override.
+        """
         super().__init__(nef, tracer, *args, **kwargs)
-        self.samples_per_ray = samples_per_ray
+        self.num_steps = num_steps if num_steps is not None else tracer.num_steps
+        self.step_size = step_size if step_size is not None else tracer.step_size
+        self.min_dis = min_dis if min_dis is not None else tracer.min_dis
         self._last_state = dict()
 
     def needs_refresh(self, payload: FramePayload, *args, **kwargs) -> bool:
-        return self._last_state.get('num_steps', 0) < self.samples_per_ray or \
+        return self._last_state.get('num_steps', 0) != self.num_steps or \
+               self._last_state.get('step_size', 0) != self.step_size or \
+               self._last_state.get('min_dis', 0) != self.min_dis or \
                self._last_state.get('channels') != self.channels
 
     def pre_render(self, payload: FramePayload, *args, **kwargs) -> None:
         super().pre_render(payload)
-        self.tracer.num_steps = self.samples_per_ray
+        self.tracer.num_steps = self.num_steps
+        self.tracer.step_size = self.step_size
+        self.tracer.min_dis = self.min_dis
         self.tracer.bg_color = 'black' if payload.clear_color == (0.0, 0.0, 0.0) else 'white'
 
     def post_render(self) -> None:
         self._last_state['num_steps'] = self.tracer.num_steps
+        self._last_state['step_size'] = self.tracer.step_size
+        self._last_state['min_dis'] = self.tracer.min_dis
         self._last_state['channels'] = self.channels

--- a/wisp/renderer/gui/imgui/widget_radiance_pipeline_renderer.py
+++ b/wisp/renderer/gui/imgui/widget_radiance_pipeline_renderer.py
@@ -38,15 +38,15 @@ class WidgetNeuralRadianceFieldRenderer(WidgetImgui):
                 if changed:
                     renderer.num_steps = value
 
-            def _num_samples_movement_property():
+            def _num_samples_interactive_property():
                 max_value = MAX_SAMPLES
                 if renderer.raymarch_type == 'ray':
                     max_value = MAX_SAMPLES_RAY_MODE
-                value = min(renderer.num_steps_movement, max_value)
-                changed, value = imgui.core.slider_int(f"##samples_per_ray_movement", value=value,
+                value = min(renderer.num_steps_interactive, max_value)
+                changed, value = imgui.core.slider_int(f"##samples_per_ray_interactive", value=value,
                                                        min_value=2, max_value=max_value)
                 if changed:
-                    renderer.num_steps_movement = value
+                    renderer.num_steps_interactive = value
 
             def _batch_size_property():
                 changed, value = imgui.core.slider_int("##batch_size", value=renderer.batch_size,
@@ -65,8 +65,8 @@ class WidgetNeuralRadianceFieldRenderer(WidgetImgui):
                     renderer.raymarch_type = new_marcher_mode
 
             properties = {
-                "Ray Samples (static)": _num_samples_property,              # Samples per ray
-                "Ray Samples (movement)": _num_samples_movement_property,   # Samples per ray
+                "Ray Samples (full-res)": _num_samples_property,                 # Samples per ray
+                "Ray Samples (interact.)": _num_samples_interactive_property,    # Samples per ray
                 "Batch Size (Rays)": _batch_size_property,
                 "Marcher Type": _marcher_type_property,
                 "Render Resolution (W x H)": f"{renderer.render_res_x} x {renderer.render_res_y}"

--- a/wisp/renderer/gui/imgui/widget_sdf_pipeline_renderer.py
+++ b/wisp/renderer/gui/imgui/widget_sdf_pipeline_renderer.py
@@ -23,9 +23,9 @@ class WidgetNeuralSDFRenderer(WidgetImgui):
     def paint_tracer(self, state: WispState, renderer: NeuralSDFPackedRenderer):
         if imgui.tree_node("Tracer", imgui.TREE_NODE_DEFAULT_OPEN):
             def _num_samples_property():
-                changed, value = imgui.core.slider_int(f"##steps_per_ray", value=renderer.samples_per_ray,
+                changed, value = imgui.core.slider_int(f"##steps_per_ray", value=renderer.num_steps,
                                                        min_value=1, max_value=256)
-                renderer.samples_per_ray = value
+                renderer.num_steps = value
 
             def _batch_size_property():
                 changed, value = imgui.core.slider_int("##batch_size", value=renderer.batch_size,


### PR DESCRIPTION
The interactive renderer's Bottom Level Renderers: `NeuralRadianceFieldPackedRenderer` and `NeuralSDFPackedRenderer` used default fixed tracer args. This is assumption was wrong: both renderers are normally constructed from some tracer (usually this tracer is the one used for optimization). The correct method is taking arguments like `num_steps` from the `tracer` they duplicate for construction. A clarification for overriding those args have also been documented.

Signed-off-by: operel <operel@nvidia.com>