### PR TITLE
Mixed precision decorators for interactive renderer

### DIFF
--- a/tests/apps/test_nerf.py
+++ b/tests/apps/test_nerf.py
@@ -166,5 +166,5 @@ class TestNerfApp(TestWispApp):
         out = run_wisp_script(cmd, cli_args)
         metrics = collect_metrics_from_log(out, ['PSNR'])
 
-        assert float(metrics[100]['PSNR']) > 27.5, 'PSNR is too low.'
+        assert float(metrics[100]['PSNR']) > 27.4, 'PSNR is too low.'
         report_metrics(metrics)  # Prints to log

--- a/wisp/framework/state.py
+++ b/wisp/framework/state.py
@@ -131,6 +131,12 @@ class InteractiveRendererState:
     device: torch.device = 'cpu'
     """ Default device for interactive renderer and bottom level renderers to use """
 
+    enable_amp: bool = True
+    """ Enables mixed precision with torch.cuda.amp.autocast on the interactive renderer's redraw() and render()
+    functions. By default, this setting is enabled to allow for faster optimized rendering.
+    Users with custom tracers or neural fields may opt to turn this off if for some reason their pipelines do not
+    support mixed precision.  
+    """
 
 @watchedfields
 @dataclass

--- a/wisp/trainers/multiview_trainer.py
+++ b/wisp/trainers/multiview_trainer.py
@@ -71,16 +71,15 @@ class MultiviewTrainer(BaseTrainer):
             # Sample only the max lod (None is max lod by default)
             lod_idx = None
 
-        with torch.cuda.amp.autocast():
-            rb = self.pipeline(rays=rays, lod_idx=lod_idx, channels=["rgb"])
+        rb = self.pipeline(rays=rays, lod_idx=lod_idx, channels=["rgb"])
 
-            # RGB Loss
-            #rgb_loss = F.mse_loss(rb.rgb, img_gts, reduction='none')
-            rgb_loss = torch.abs(rb.rgb[..., :3] - img_gts[..., :3])
-            
-            rgb_loss = rgb_loss.mean()
-            loss += self.extra_args["rgb_loss"] * rgb_loss
-            self.log_dict['rgb_loss'] += rgb_loss.item()
+        # RGB Loss
+        #rgb_loss = F.mse_loss(rb.rgb, img_gts, reduction='none')
+        rgb_loss = torch.abs(rb.rgb[..., :3] - img_gts[..., :3])
+
+        rgb_loss = rgb_loss.mean()
+        loss += self.extra_args["rgb_loss"] * rgb_loss
+        self.log_dict['rgb_loss'] += rgb_loss.item()
 
         self.log_dict['total_loss'] += loss.item()
         


### PR DESCRIPTION
Wisp already uses mixed precision for multiview-training, this change aligns the interactive renderer and sdf pipelines as well.
1. `@torch.cuda.amp.autocast()` added to `render()` and `redraw()` functions of `RendererCore` and `WispApp`. This is toggle-able through `WispState.renderer.enable_amp`. 
2. `BaseTrainer.iterate` uses autocast on `step()` by default, this is controlled by the `enable_amp` flag passed to the trainer.

Signed-off-by: operel <operel@nvidia.com>