### PR TITLE
[#131] Fix skimage SSIM win_size error

### DIFF
--- a/wisp/ops/image/metrics.py
+++ b/wisp/ops/image/metrics.py
@@ -87,4 +87,5 @@ def ssim(rgb, gts):
         multichannel=True,
         data_range=1,
         gaussian_weights=True,
-        sigma=1.5)
+        sigma=1.5,
+        channel_axis=-1)


### PR DESCRIPTION
Addressing issue #131 

Running the demos on the README leads to an error due to skimage thinking that the color channel for the images used for SSIM are part of the image dimension rather than channels.
Maybe the tests have been run with a different version of skimage?

Running the demo script:
`python3 app/nerf/main_nerf.py --config ./app/nerf/configs/nerf_hash.yaml  --dataset-path path/to/dataset/ --dataset-num-workers 4`
works for me after this edit.