### PR TITLE
Fix Renderer/NeF compatibility check when NeF has multiple inheritance

### DIFF
--- a/wisp/renderer/core/api/renderers_factory.py
+++ b/wisp/renderer/core/api/renderers_factory.py
@@ -59,7 +59,7 @@ def _neural_field_to_renderer_cls(pipeline: Pipeline) -> Type[RayTracedRenderer]
             else:   # Try querying all parent(nef) + tracer combos for compatibility
                 bases = field_type.__bases__
                 if len(bases) > 0:
-                    type_queue.append(*bases)
+                    type_queue.append(bases)
 
         if renderer_cls is not None:
             break   # Found a renderer class


### PR DESCRIPTION
NeF tracer compatibility check fails when it extends multiple classes. 

The issue is that the queue append method takes a single element and bu unpacking it with the star operator, when a NeF inherits from multiple classes, the append method fails.

Fixed by avoiding unpacking the base class types for appending to the class names queue.