### PR TITLE
Update renderers_factory.py

### DIFF
--- a/wisp/renderer/core/api/renderers_factory.py
+++ b/wisp/renderer/core/api/renderers_factory.py
@@ -59,7 +59,7 @@ def _neural_field_to_renderer_cls(pipeline: Pipeline) -> Type[RayTracedRenderer]
             else:   # Try querying all parent(nef) + tracer combos for compatibility
                 bases = field_type.__bases__
                 if len(bases) > 0:
-                    type_queue.append(*bases)
+                    type_queue.append(bases)
 
         if renderer_cls is not None:
             break   # Found a renderer class


### PR DESCRIPTION
NeF tracer compatibility check fails when it extends multiple classes. Fixed by avoid unpacking base classes to properly append to base class names queue.