### PR TITLE
Lower mem footprint for Jupyter

### DIFF
--- a/examples/notebook/view_pretrained.ipynb
+++ b/examples/notebook/view_pretrained.ipynb
@@ -133,7 +133,7 @@
     "# Initialize\n",
     "wisp_state = WispState()\n",
     "wisp_state.renderer.target_fps = 10\n",
-    "add_pipeline_to_scene_graph(wisp_state, 'my neural field', pipeline) \n",
+    "add_pipeline_to_scene_graph(wisp_state, 'my neural field', pipeline, batch_size=2**14)\n",
     "render_core = RendererCore(wisp_state)\n",
     "render_core.redraw()\n",
     "\n",


### PR DESCRIPTION
Passes raypack `batch_size` for inference time