### PR TITLE
wire coord grads from kernel

### DIFF
--- a/wisp/csrc/ops/hashgrid_interpolate.cpp
+++ b/wisp/csrc/ops/hashgrid_interpolate.cpp
@@ -65,7 +65,7 @@ at::Tensor hashgrid_interpolate_cuda(
 #endif  // WITH_CUDA
 }
 
-at::Tensor hashgrid_interpolate_backward_cuda(
+std::vector<at::Tensor> hashgrid_interpolate_backward_cuda(
     at::Tensor coords,
     at::Tensor grad_output,
     at::Tensor codebook,
@@ -93,7 +93,7 @@ at::Tensor hashgrid_interpolate_backward_cuda(
                 resolution[i], i, num_lods, require_grad_coords,
                 coords, codebook, codebook_first_idx, grad_output, grad_codebook, grad_coords);
     }
-    return grad_codebook;
+    return {grad_codebook, grad_coords};
 #else
     AT_ERROR(__func__);
 #endif  // WITH_CUDA

--- a/wisp/csrc/ops/hashgrid_interpolate.h
+++ b/wisp/csrc/ops/hashgrid_interpolate.h
@@ -22,7 +22,7 @@ at::Tensor hashgrid_interpolate_cuda(
     std::vector<int32_t> resolution,
     int32_t codebook_bitwidth);
 
-at::Tensor hashgrid_interpolate_backward_cuda(
+std::vector<at::Tensor> hashgrid_interpolate_backward_cuda(
     at::Tensor coords,
     at::Tensor grad_output,
     at::Tensor codebook,


### PR DESCRIPTION
A fix for hashgrid grad by coords not being passed back from backward kernel.

See discussion in issue [!142](https://github.com/NVIDIAGameWorks/kaolin-wisp/issues/142).