### PR TITLE
Fix torch 2.0 compatability

### DIFF
--- a/docs/pages/main.md
+++ b/docs/pages/main.md
@@ -71,9 +71,9 @@ The Wisp repository also includes some sample apps aand examples:
 Want to run the Wisp apps with different options? Our configuration system makes this very easy.
 
 Wisp apps use a mixture of config files and CLI arguments, which take higher precedence.
-For example, if you want to run NeRF with a different number of levels of details:
+For example, if you want to run NeRF with a different number of hidden layer neurons:
 ```
-python3 app/nerf/main_nerf.py --config app/nerf/configs/nerf_octree.yaml --dataset-path /path/to/lego --num-lods 1
+python3 app/nerf/main_nerf.py --config app/nerf/configs/nerf_hash.yaml --dataset-path /path/to/lego --hidden_dim 128
 ```
 
 Arg values not specified through yaml or CLI will resort to the default value the main script specifies, when available.

--- a/wisp/datasets/utils.py
+++ b/wisp/datasets/utils.py
@@ -12,7 +12,6 @@ from typing import Callable, Optional, Type
 import collections
 import inspect
 import torch
-from torch._six import string_classes
 from torch.utils.data._utils.collate import default_convert, default_collate_err_msg_format
 from wisp.core import Rays
 from wisp.datasets.base_datasets import WispDataset, MultiviewDataset, SDFDataset
@@ -154,7 +153,7 @@ def default_collate(batch):
         return torch.tensor(batch, dtype=torch.float64)
     elif isinstance(elem, int):
         return torch.tensor(batch)
-    elif isinstance(elem, string_classes):
+    elif isinstance(elem, (str, bytes)):
         return batch
     elif isinstance(elem, collections.abc.Mapping):
         try:


### PR DESCRIPTION
1. Fixes torch 2.0 compatibility issue with `torch._six`
2. Corrects `nerf_octree` documentation incorrectly pointing at lego dataset by default (config uses RTMV by default)