### PR TITLE
Fixing unexpected processing of iterate() of BaseTrainer

### DIFF
--- a/wisp/trainers/base_trainer.py
+++ b/wisp/trainers/base_trainer.py
@@ -334,15 +334,14 @@ class BaseTrainer(ABC):
                 if self.is_any_iterations_remaining():
                     self.begin_epoch()
                     data = self.next_batch()
+                else:
+                    self.post_training()
             if self.is_any_iterations_remaining():
                 self.pre_step()
                 with torch.cuda.amp.autocast(self.enable_amp):
                     self.step(data)
                 self.post_step()
-                iter_end_time = time.time()
-            else:
-                iter_end_time = time.time()
-                self.post_training()
+            iter_end_time = time.time()
             self.scene_state.optimization.elapsed_time += iter_end_time - iter_start_time
 
     def save_model(self):

--- a/wisp/trainers/base_trainer.py
+++ b/wisp/trainers/base_trainer.py
@@ -138,7 +138,7 @@ class BaseTrainer(ABC):
 
         # Training params
         self.epoch = 1
-        self.iteration = 0
+        self.iteration = 1
         self.max_epochs = num_epochs
         self.batch_size = batch_size
         self.exp_name = exp_name if exp_name else "unnamed_experiment"
@@ -321,6 +321,7 @@ class BaseTrainer(ABC):
         """Advances the training by one training step (batch).
         """
         if self.is_optimization_running:
+            print(f"{self.is_first_iteration()=}")
             if self.is_first_iteration():
                 self.pre_training()
             iter_start_time = time.time()

--- a/wisp/trainers/base_trainer.py
+++ b/wisp/trainers/base_trainer.py
@@ -321,7 +321,6 @@ class BaseTrainer(ABC):
         """Advances the training by one training step (batch).
         """
         if self.is_optimization_running:
-            print(f"{self.is_first_iteration()=}")
             if self.is_first_iteration():
                 self.pre_training()
             iter_start_time = time.time()


### PR DESCRIPTION
Hi, thanks for developing such an amazing library. This is a PR to fix the unexpected behaviour of `iterate()`. Please refer to the following description. I hope this request will be approved.

## Changes proposed in this PR
* Initial value for `self.iteration` of BaseTrainer in the `stable` branch.
* Processing flow inside `iterate()` of the class

## Reason for the proposal
The original iterate() calls `step()` before `pre_training()`, and `post_training()` before and after the last `step()`.

## Reference
BaseTrainer in the `main` branch