### PR TITLE
Rasterization pipeline for interactive renderer

### DIFF
--- a/ci/gitlab_jenkins_templates/core_ci.jenkins
+++ b/ci/gitlab_jenkins_templates/core_ci.jenkins
@@ -6,7 +6,7 @@ import groovy.transform.Field
 // (See: https://hub.docker.com/r/pytorch/pytorch/tags)
 def ubuntu_from_kaolin_configs = [
     [
-        'imageTag': 'master-2235-custom-torch1.13.1-cuda11.6.1-cudnn8-py3.9',
+        'imageTag': 'master-2670-custom-torch1.11.0-cuda11.3.1-cudnn8-py3.8',
         'archsToTest': 'GA100-E4720-DVT'
     ],
 ]

--- a/wisp/models/__init__.py
+++ b/wisp/models/__init__.py
@@ -7,3 +7,4 @@
 # license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
 
 from .pipeline import Pipeline
+from .rasterization_pipeline import RasterizationPipeline

--- a/wisp/models/rasterization_pipeline.py
+++ b/wisp/models/rasterization_pipeline.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# NVIDIA CORPORATION & AFFILIATES and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION & AFFILIATES is strictly prohibited.
+
+import torch.nn as nn
+
+
+class RasterizationPipeline(nn.Module):
+    """ Wrapper class for implementing neural / non-neural Rasterization pipelines.
+    RasterizationPipeline is a thin wrapper around existing rasterizers, which simply hints wisp
+    the wrapped object is a rasterizer which relies on camera input, rather than rays.
+    """
+    
+    def __init__(self, rasterizer):
+        """Initialize the Pipeline.
+
+        Args:
+            rasterizer: A general model of a rasterizer.
+                No assumptions are made on the rasterizer object. The only requirement is
+                for this object to be callable.
+                Rasterizers are encouraged to return a Renderbuffer object, but are not required to do so.
+        """
+        super().__init__()
+        self.rasterizer = rasterizer
+
+    def forward(self, *args, **kwargs):
+        """The forward function will invoke the underlying rasterizer (the forward model).
+        Rasterizer is any general callable interface.
+        """
+        return self.rasterizer(*args, **kwargs)

--- a/wisp/renderer/core/api/base_renderer.py
+++ b/wisp/renderer/core/api/base_renderer.py
@@ -13,6 +13,7 @@ from typing import Optional, Dict, Set, Tuple, Any
 import torch
 from kaolin.render.camera import Camera
 from wisp.core import RenderBuffer, Rays, PrimitivesPack, WispModule
+from wisp.models import RasterizationPipeline
 
 
 @dataclass
@@ -102,6 +103,12 @@ class BottomLevelRenderer(WispModule, ABC):
 class RasterizedRenderer(BottomLevelRenderer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    @classmethod
+    def from_pipeline(cls, pipeline: RasterizationPipeline, **kwargs):
+        """ Builds a bottom level renderer from the building block of a pipeline. """
+        # Pass the kwargs to the renderer also, in case it wants to further modify the tracer with them.
+        return cls(model=pipeline.rasterizer, **kwargs)
 
     @abstractmethod
     def render(self, camera: Camera) -> RenderBuffer:

--- a/wisp/renderer/core/api/decorators.py
+++ b/wisp/renderer/core/api/decorators.py
@@ -11,7 +11,7 @@ from typing import Type
 from wisp.models.nefs import BaseNeuralField
 from wisp.tracers import BaseTracer
 from wisp.renderer.core.api.base_renderer import BottomLevelRenderer
-from wisp.renderer.core.api.renderers_factory import register_neural_field_type
+from wisp.renderer.core.api.renderers_factory import register_neural_field_type, register_rasterizer_type
 
 
 def field_renderer(field_type: Type[BaseNeuralField], tracer_type: Type[BaseTracer]):
@@ -22,5 +22,16 @@ def field_renderer(field_type: Type[BaseNeuralField], tracer_type: Type[BaseTrac
     """
     def _register_renderer_fn(renderer_class: Type[BottomLevelRenderer]):
         register_neural_field_type(field_type, tracer_type, renderer_class)
+        return renderer_class
+    return _register_renderer_fn
+
+def register_rasterizer(rasterizer_type: Type):
+    """ A decorator that registers a rasterizer type with a renderer.
+        By registering the renderer type, the interactive renderer knows what type of renderer to create
+        when dealing with this type of rasterizer.
+        Essentially, this allows displaying custom types of objects on the canvas.
+    """
+    def _register_renderer_fn(renderer_class: Type[BottomLevelRenderer]):
+        register_rasterizer_type(rasterizer_type, renderer_class)
         return renderer_class
     return _register_renderer_fn


### PR DESCRIPTION
Enables visualizing rasterized pipelines within the interactive renderer, i.e. rendered meshes.
`RasterizedRenderer` is now patched to support rasterized objects within the scene graph.
This MR does not support optimization of differentiable rasterizers (see kaolin DIB-R / nvdiffrast).

The usage of this MR is intended to be as follows:
```
from wisp.renderer.core.api import RasterizedRenderer, register_rasterizer
@register_rasterizer(YOUR_RASTERIZER_CLASS_HERE)
class YourWispSceneGraphNodeRenderer(RasterizedRenderer): 
     @torch.no_grad()
     def render(self, camera: Camera) -> RenderBuffer:
              ...
```