### PR TITLE
Make sure tracker actually logs config and fix key filtering

### DIFF
--- a/app/nerf/main_nerf.py
+++ b/app/nerf/main_nerf.py
@@ -106,6 +106,7 @@ else:  # Create model from scratch
 exp_name: str = cfg.trainer.exp_name
 scene_state: WispState = WispState()
 tracker = Tracker(cfg=cfg.tracker, exp_name=exp_name)
+tracker.save_app_config(cfg)
 trainer = MultiviewTrainer(cfg=cfg.trainer,
                            pipeline=pipeline,
                            train_dataset=train_dataset,

--- a/wisp/trainers/multiview_trainer.py
+++ b/wisp/trainers/multiview_trainer.py
@@ -254,17 +254,10 @@ class MultiviewTrainer(BaseTrainer):
 
         self.pipeline.eval()
         
-        record_dict = self.tracker.get_app_config(as_dict=True)
+        record_dict = self.tracker.get_record_dict()
         if record_dict is None:
             log.info("app_config not supplied to Tracker, config won't be logged in the pandas log")
             record_dict = {}
-        else:
-            record_dict = pd.json_normalize(record_dict, sep='.').to_dict(orient='records')[0]
-
-        # record_dict contains config args, but omits torch.Tensor fields which were not explicitly converted to
-        # numpy or some other format. This is required as parquet doesn't support torch.Tensors
-        # (and also for output size considerations)
-        record_dict = {k: v for k, v in record_dict.items() if not isinstance(v, torch.Tensor)}
 
         try:
             repo = git.Repo(search_parent_directories=True)


### PR DESCRIPTION
Right now keys that are not actually config elements would get stored in the dataframe.

In addition, make sure the config is logged by default. 