### PR TITLE
Implement closest_point function

### DIFF
--- a/wisp/csrc/bindings.cpp
+++ b/wisp/csrc/bindings.cpp
@@ -22,6 +22,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     render.def("find_depth_bound_cuda", &find_depth_bound_cuda);
     py::module external = m.def_submodule("external");
     external.def("mesh_to_sdf_cuda", &mesh_to_sdf_cuda);
+    external.def("mesh_to_sdf_triangle_cuda", &mesh_to_sdf_triangle_cuda);
     py::module ops = m.def_submodule("ops");
     ops.def("hashgrid_interpolate_cuda", &hashgrid_interpolate_cuda);
     ops.def("hashgrid_interpolate_backward_cuda", &hashgrid_interpolate_backward_cuda);

--- a/wisp/csrc/external/mesh2sdf_kernel.cu
+++ b/wisp/csrc/external/mesh2sdf_kernel.cu
@@ -47,86 +47,86 @@ THE SOFTWARE.
 //    THCudaCheck(cudaGetLastError());
 
 // dot product
-inline __host__ __device__ float dot(float3 a, float3 b)
-{ 
+inline __host__ __device__ double dot(double3 a, double3 b)
+{
     return a.x * b.x + a.y * b.y + a.z * b.z;
 }
 
-inline __host__ __device__ float dot(const float* a, float3 b)
-{ 
+inline __host__ __device__ double dot(const double* a, double3 b)
+{
     return a[0] * b.x + a[1] * b.y + a[2] * b.z;
 }
 
-inline __host__ __device__ float dot(const float* a, const float* b)
-{ 
+inline __host__ __device__ double dot(const double* a, const double* b)
+{
     return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
-inline __device__ float idot2(const float* a)
-{ 
+inline __device__ double idot2(const double* a)
+{
     return __frcp_rn(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
 }
 
-inline __device__ float3 normalize(float3 a)
-{ 
-    float norm = sqrtf(a.x*a.x + a.y*a.y + a.z*a.z);
+inline __device__ double3 normalize(double3 a)
+{
+    double norm = sqrtf(a.x*a.x + a.y*a.y + a.z*a.z);
     a.x /= norm;
     a.y /= norm;
     a.z /= norm;
     return a;
 }
 
-inline __host__ __device__ float sign(float x)
-{ 
+inline __host__ __device__ double sign(double x)
+{
     return copysignf(1.0, x);
 }
 
-inline __device__ __host__ float clamp(float f, float a, float b)
+inline __device__ __host__ double clamp(double f, double a, double b)
 {
     return fmaxf(a, fminf(f, b));
 }
 
-inline __device__ __host__ float d2axmb(const float* a, float x, const float* b)
+inline __device__ __host__ double d2axmb(const double* a, double x, const double* b)
 {
-    float t0 = a[0] * x - b[0];
-    float t1 = a[1] * x - b[1];
-    float t2 = a[2] * x - b[2];
+    double t0 = a[0] * x - b[0];
+    double t1 = a[1] * x - b[1];
+    double t2 = a[2] * x - b[2];
     return t0*t0 + t1*t1 + t2*t2;
 }
 
-inline __device__ __host__ float d2axmb(const float* a, float x, float3 b)
+inline __device__ __host__ double d2axmb(const double* a, double x, double3 b)
 {
-    float t0 = a[0] * x - b.x;
-    float t1 = a[1] * x - b.y;
-    float t2 = a[2] * x - b.z;
+    double t0 = a[0] * x - b.x;
+    double t1 = a[1] * x - b.y;
+    double t2 = a[2] * x - b.z;
     return t0*t0 + t1*t1 + t2*t2;
 }
 
-inline __device__ __host__ float d2axmb(float3 a, float x, float3 b)
+inline __device__ __host__ double d2axmb(double3 a, double x, double3 b)
 {
-    float t0 = a.x * x - b.x;
-    float t1 = a.y * x - b.y;
-    float t2 = a.z * x - b.z;
+    double t0 = a.x * x - b.x;
+    double t1 = a.y * x - b.y;
+    double t2 = a.z * x - b.z;
     return t0*t0 + t1*t1 + t2*t2;
 }
 
 // cross product
-inline __host__ __device__ float3 cross(float3 a, float3 b)
-{ 
-    return make_float3(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x); 
+inline __host__ __device__ double3 cross(double3 a, double3 b)
+{
+    return make_double3(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x);
 }
 
-inline __host__ __device__ float3 cross(float3 a, const float* b)
-{ 
-    return make_float3(a.y*b[2] - a.z*b[1], a.z*b[0] - a.x*b[2], a.x*b[1] - a.y*b[0]); 
+inline __host__ __device__ double3 cross(double3 a, const double* b)
+{
+    return make_double3(a.y*b[2] - a.z*b[1], a.z*b[0] - a.x*b[2], a.x*b[1] - a.y*b[0]);
 }
 
-inline __host__ __device__ float3 cross(const float* a, const float* b)
-{ 
-    return make_float3(a[1]*b[2] - a[2]*b[1], a[2]*b[0] - a[0]*b[2], a[0]*b[1] - a[1]*b[0]); 
+inline __host__ __device__ double3 cross(const double* a, const double* b)
+{
+    return make_double3(a[1]*b[2] - a[2]*b[1], a[2]*b[0] - a[0]*b[2], a[0]*b[1] - a[1]*b[0]);
 }
 
-inline __host__ __device__ void cross(const float* a, const float* b, float* res)
+inline __host__ __device__ void cross(const double* a, const double* b, double* res)
 {
     res[0] = a[1]*b[2] - a[2]*b[1];
     res[1] = a[2]*b[0] - a[0]*b[2];
@@ -139,35 +139,35 @@ inline __host__ __device__ void cross(const float* a, const float* b, float* res
           dest.z=v1.z-v2.z;
 
 __global__ void kernel_mesh2sdf(
-    const int num_points, 
-    const float* __restrict__ points,
-    const int num_triangles, 
-    const float* __restrict__ mesh,
-    const float* __restrict__ v10,
-    const float* __restrict__ v21,
-    const float* __restrict__ v02,
-    const float* __restrict__ nor,
-    const float* __restrict__ c_v10_nor,
-    const float* __restrict__ c_v21_nor,
-    const float* __restrict__ c_v02_nor,
-    const float* __restrict__ inv_dot2_v10,
-    const float* __restrict__ inv_dot2_v21,
-    const float* __restrict__ inv_dot2_v02,
-    const float* __restrict__ inv_dot2_nor,
-    float* __restrict__ output) {
-    
+    const int num_points,
+    const double* __restrict__ points,
+    const int num_triangles,
+    const double* __restrict__ mesh,
+    const double* __restrict__ v10,
+    const double* __restrict__ v21,
+    const double* __restrict__ v02,
+    const double* __restrict__ nor,
+    const double* __restrict__ c_v10_nor,
+    const double* __restrict__ c_v21_nor,
+    const double* __restrict__ c_v02_nor,
+    const double* __restrict__ inv_dot2_v10,
+    const double* __restrict__ inv_dot2_v21,
+    const double* __restrict__ inv_dot2_v02,
+    const double* __restrict__ inv_dot2_nor,
+    double* __restrict__ output) {
+
     int index = blockIdx.x * blockDim.x + threadIdx.x;
-    
+
     if (index >= num_points) {
         return;
     }
-    
-    const float* point_ptr = points + index * 3;
-    float mindistsq = INFINITY;
+
+    const double* point_ptr = points + index * 3;
+    double mindistsq = INFINITY;
     //int num_intersect = 0;
     int pos_intersect[13] = {0,0,0,0,0,0,0,0,0,0,0,0,0};
     int neg_intersect[13] = {0,0,0,0,0,0,0,0,0,0,0,0,0};
-    float stab_dir_table[13][3] = { {1.0f, 0.0f, 0.0f},
+    double stab_dir_table[13][3] = { {1.0f, 0.0f, 0.0f},
                                     {0.0f, 1.0f, 0.0f},
                                     {0.0f, 0.0f, 1.0f},
                                     {0.0f, 1.0f, 1.0f},
@@ -180,23 +180,23 @@ __global__ void kernel_mesh2sdf(
                                     {-1.0f, 1.0f, 1.0f},
                                     {1.0f, -1.0f, 1.0f},
                                     {1.0f, 1.0f, -1.0f}};
-    
+
     // Loop over each triangle
     for (int i=0; i<num_triangles; i++) {
-        const float* triangle_ptr = mesh + i * 9;
-        const float* v10_ptr = v10 + i * 3;
-        const float* v21_ptr = v21 + i * 3;
-        const float* v02_ptr = v02 + i * 3;
-        const float* nor_ptr = nor + i * 3;
-        const float* c_v10_nor_ptr = c_v10_nor + i * 3;
-        const float* c_v21_nor_ptr = c_v21_nor + i * 3;
-        const float* c_v02_nor_ptr = c_v02_nor + i * 3;
-        float inv_dot2_v10_val = inv_dot2_v10[i];
-        float inv_dot2_v21_val = inv_dot2_v21[i];
-        float inv_dot2_v02_val = inv_dot2_v02[i];
-        float inv_dot2_nor_val = inv_dot2_nor[i];
+        const double* triangle_ptr = mesh + i * 9;
+        const double* v10_ptr = v10 + i * 3;
+        const double* v21_ptr = v21 + i * 3;
+        const double* v02_ptr = v02 + i * 3;
+        const double* nor_ptr = nor + i * 3;
+        const double* c_v10_nor_ptr = c_v10_nor + i * 3;
+        const double* c_v21_nor_ptr = c_v21_nor + i * 3;
+        const double* c_v02_nor_ptr = c_v02_nor + i * 3;
+        double inv_dot2_v10_val = inv_dot2_v10[i];
+        double inv_dot2_v21_val = inv_dot2_v21[i];
+        double inv_dot2_v02_val = inv_dot2_v02[i];
+        double inv_dot2_nor_val = inv_dot2_nor[i];
 
-        float3 p0, p1, p2;
+        double3 p0, p1, p2;
         p0.x = point_ptr[0] - triangle_ptr[0];
         p0.y = point_ptr[1] - triangle_ptr[1];
         p0.z = point_ptr[2] - triangle_ptr[2];
@@ -206,21 +206,21 @@ __global__ void kernel_mesh2sdf(
         p2.x = point_ptr[0] - triangle_ptr[6];
         p2.y = point_ptr[1] - triangle_ptr[7];
         p2.z = point_ptr[2] - triangle_ptr[8];
-        
+
         // if the normal vector is zero, the triangle is degenerative.
         if (nor_ptr[0] != 0.0f || nor_ptr[1] != 0.0f || nor_ptr[2] != 0.0f) {
-                
-            float s1 = sign(dot(c_v10_nor_ptr, p0));
-            float s2 = sign(dot(c_v21_nor_ptr, p1));
-            float s3 = sign(dot(c_v02_nor_ptr, p2));
-            
-            float distsq;
+
+            double s1 = sign(dot(c_v10_nor_ptr, p0));
+            double s2 = sign(dot(c_v21_nor_ptr, p1));
+            double s3 = sign(dot(c_v02_nor_ptr, p2));
+
+            double distsq;
             if ((s1+s2+s3) < 2.0f) {
             //if (0) {
                 // Edge dist
-                float ed1 = d2axmb(v10_ptr, clamp(dot(v10_ptr,p0)*inv_dot2_v10_val,0.0f,1.0f), p0);
-                float ed2 = d2axmb(v21_ptr, clamp(dot(v21_ptr,p1)*inv_dot2_v21_val,0.0f,1.0f), p1);
-                float ed3 = d2axmb(v02_ptr, clamp(dot(v02_ptr,p2)*inv_dot2_v02_val,0.0f,1.0f), p2);
+                double ed1 = d2axmb(v10_ptr, clamp(dot(v10_ptr,p0)*inv_dot2_v10_val,0.0f,1.0f), p0);
+                double ed2 = d2axmb(v21_ptr, clamp(dot(v21_ptr,p1)*inv_dot2_v21_val,0.0f,1.0f), p1);
+                double ed3 = d2axmb(v02_ptr, clamp(dot(v02_ptr,p2)*inv_dot2_v02_val,0.0f,1.0f), p2);
                 distsq = fminf(ed1, fminf(ed2, ed3));
             } else {
                 // Face dist
@@ -232,23 +232,23 @@ __global__ void kernel_mesh2sdf(
             //distsq = fabs(distsq);
             mindistsq = fminf(mindistsq, distsq);
         }
-        
+
         // Calculate inside/outside
         // With triangle-ray intersection
         // center: point_ptr
         // direction: -point_ptr
         // Triangle: triangle_ptr [x y z x y z x y z]
-        //float3 tvec;
-        float3 edge1, edge2;
+        //double3 tvec;
+        double3 edge1, edge2;
         edge1.x = triangle_ptr[3] - triangle_ptr[0];
         edge1.y = triangle_ptr[4] - triangle_ptr[1];
         edge1.z = triangle_ptr[5] - triangle_ptr[2];
         edge2.x = triangle_ptr[6] - triangle_ptr[0];
         edge2.y = triangle_ptr[7] - triangle_ptr[1];
         edge2.z = triangle_ptr[8] - triangle_ptr[2];
-        
-        float3 dir;
-        
+
+        double3 dir;
+
         // test 4 directions
         // more directions:
         // (1 0 0), (0 1 0), (0 0 1)
@@ -259,44 +259,44 @@ __global__ void kernel_mesh2sdf(
             dir.x = stab_dir_table[i][0];
             dir.y = stab_dir_table[i][1];
             dir.z = stab_dir_table[i][2];
-            
 
-            float3 pvec = cross(dir, edge2);
-            float det = dot(edge1, pvec);
-            //float3 pvec = cross(point_ptr, v02_ptr); // Both have negative direction, result have correct direction
-            //float det = dot(v10_ptr, pvec);
-            
-            
+
+            double3 pvec = cross(dir, edge2);
+            double det = dot(edge1, pvec);
+            //double3 pvec = cross(point_ptr, v02_ptr); // Both have negative direction, result have correct direction
+            //double det = dot(v10_ptr, pvec);
+
+
             if (det > -1e-5 && det < 1e-5) // No intersection at all
                 continue;
-            float inv_det = 1.0f / det;
-            
-            float3 tvec;
+            double inv_det = 1.0f / det;
+
+            double3 tvec;
             tvec.x = point_ptr[0] - triangle_ptr[0];
             tvec.y = point_ptr[1] - triangle_ptr[1];
             tvec.z = point_ptr[2] - triangle_ptr[2];
-            
-            
+
+
             // tvec = orig - vert0
             //tvec = p0;
             // Calculate barycentric uvs
-            //float u = dot(p0, pvec) * inv_det;
-            float u = dot(tvec, pvec) * inv_det;
+            //double u = dot(p0, pvec) * inv_det;
+            double u = dot(tvec, pvec) * inv_det;
             if (u < 0.0f || u > 1.0f) { // u out of bound
                 continue;
             }
-            //float3 qvec = cross(p0, v10_ptr);
-            float3 qvec = cross(tvec, edge1);
-            
-            //float v = - dot(point_ptr, qvec) * inv_det;
-            float v = dot(dir, qvec) * inv_det;
+            //double3 qvec = cross(p0, v10_ptr);
+            double3 qvec = cross(tvec, edge1);
+
+            //double v = - dot(point_ptr, qvec) * inv_det;
+            double v = dot(dir, qvec) * inv_det;
             if (v < 0.0f || u + v > 1.0f) {
                 continue;
             }
-            
+
             // Ray intersects triangle
-            //float t = - dot(v02_ptr, qvec) * inv_det;
-            float t = dot(edge2, qvec) * inv_det;
+            //double t = - dot(v02_ptr, qvec) * inv_det;
+            double t = dot(edge2, qvec) * inv_det;
 
             if (t >= 0.0f)
                 pos_intersect[i] = 1;
@@ -307,9 +307,9 @@ __global__ void kernel_mesh2sdf(
             //}
         }
     }
-    
-    float mindist = sqrtf(mindistsq);
-    
+
+    double mindist = sqrtf(mindistsq);
+
     int outside = 0;
     for (int i=0; i<13; i++) {
         if (pos_intersect[i] == 0 || neg_intersect[i] == 0) { // if outside
@@ -332,18 +332,18 @@ __global__ void kernel_mesh2sdf(
 }
 
 __global__ void kernel_mesh2sdf_quad(
-    const int num_points, 
-    const float* __restrict__ points,
-    const int num_triangles, 
-    const float* __restrict__ mesh,
-    float* __restrict__ output,
+    const int num_points,
+    const double* __restrict__ points,
+    const int num_triangles,
+    const double* __restrict__ mesh,
+    double* __restrict__ output,
     uint8_t* __restrict__ raystab_results) {
     const int split_factor = SPLIT_FACTOR;
     int index = blockIdx.x * blockDim.x + threadIdx.x;
-    
+
     int pindex = index % num_points;
     int rindex = index / num_points;
-    
+
     if (rindex >= split_factor) {
         return;
     }
@@ -351,21 +351,21 @@ __global__ void kernel_mesh2sdf_quad(
     int tranksize = (num_triangles + split_factor - 1) / split_factor;
     int tstart = tranksize * rindex;
     int tend = min(tstart + tranksize, num_triangles);
-    
+
     // SPLIT_FACTOR, num_points, 13, 2
     uint8_t* raystab_cache_base = raystab_results + rindex * num_points * 13 * 2 + pindex * 13 * 2;
     // SPLIT_FACTOR, num_points
-    float* output_base = output + rindex * num_points;
-    
-    const float* point_ptr = points + pindex * 3;
-    float mindistsq = INFINITY;
+    double* output_base = output + rindex * num_points;
+
+    const double* point_ptr = points + pindex * 3;
+    double mindistsq = INFINITY;
     //int num_intersect = 0;
     //int pos_intersect[13] = {0,0,0,0,0,0,0,0,0,0,0,0,0};
     //int neg_intersect[13] = {0,0,0,0,0,0,0,0,0,0,0,0,0};
     uint8_t* pos_intersect = raystab_cache_base;
     uint8_t* neg_intersect = raystab_cache_base + 13;
-    
-    float stab_dir_table[13][3] = { {1.0f, 0.0f, 0.0f},
+
+    double stab_dir_table[13][3] = { {1.0f, 0.0f, 0.0f},
                                     {0.0f, 1.0f, 0.0f},
                                     {0.0f, 0.0f, 1.0f},
                                     {0.0f, 0.707106781f, 0.707106781f},
@@ -378,15 +378,15 @@ __global__ void kernel_mesh2sdf_quad(
                                     {-0.577350269f, 0.577350269f, 0.577350269f},
                                     {0.577350269f, -0.577350269f, 0.577350269f},
                                     {0.577350269f, 0.577350269f, -0.577350269f}};
-    
+
     // Loop over each triangle
     //for (int i=0; i<num_triangles; i++) {
     for (int i=tstart; i<tend; i++) {
-    
-        const float* triangle_ptr = mesh + i * 9;
-        float v10_ptr[3];
-        float v21_ptr[3];
-        float v02_ptr[3];
+
+        const double* triangle_ptr = mesh + i * 9;
+        double v10_ptr[3];
+        double v21_ptr[3];
+        double v02_ptr[3];
         v10_ptr[0] = triangle_ptr[3] - triangle_ptr[0];
         v10_ptr[1] = triangle_ptr[4] - triangle_ptr[1];
         v10_ptr[2] = triangle_ptr[5] - triangle_ptr[2];
@@ -396,35 +396,35 @@ __global__ void kernel_mesh2sdf_quad(
         v02_ptr[0] = triangle_ptr[0] - triangle_ptr[6];
         v02_ptr[1] = triangle_ptr[1] - triangle_ptr[7];
         v02_ptr[2] = triangle_ptr[2] - triangle_ptr[8];
-        
-        float nor_ptr[3];
+
+        double nor_ptr[3];
         cross(v10_ptr, v02_ptr, nor_ptr);
-        
-        float c_v10_nor_ptr[3];
-        float c_v21_nor_ptr[3];
-        float c_v02_nor_ptr[3];
+
+        double c_v10_nor_ptr[3];
+        double c_v21_nor_ptr[3];
+        double c_v02_nor_ptr[3];
         cross(v10_ptr, nor_ptr, c_v10_nor_ptr);
         cross(v21_ptr, nor_ptr, c_v21_nor_ptr);
         cross(v02_ptr, nor_ptr, c_v02_nor_ptr);
-        
-        float inv_dot2_v10_val = idot2(v10_ptr);
-        float inv_dot2_v21_val = idot2(v21_ptr);
-        float inv_dot2_v02_val = idot2(v02_ptr);
-        float inv_dot2_nor_val = idot2(nor_ptr);
-        
-        //const float* v10_ptr = v10 + i * 3;
-        //const float* v21_ptr = v21 + i * 3;
-        //const float* v02_ptr = v02 + i * 3;
-        //const float* nor_ptr = nor + i * 3;
-        //const float* c_v10_nor_ptr = c_v10_nor + i * 3;
-        //const float* c_v21_nor_ptr = c_v21_nor + i * 3;
-        //const float* c_v02_nor_ptr = c_v02_nor + i * 3;
-        //float inv_dot2_v10_val = inv_dot2_v10[i];
-        //float inv_dot2_v21_val = inv_dot2_v21[i];
-        //float inv_dot2_v02_val = inv_dot2_v02[i];
-        //float inv_dot2_nor_val = inv_dot2_nor[i];
 
-        float p0[3], p1[3], p2[3];
+        double inv_dot2_v10_val = idot2(v10_ptr);
+        double inv_dot2_v21_val = idot2(v21_ptr);
+        double inv_dot2_v02_val = idot2(v02_ptr);
+        double inv_dot2_nor_val = idot2(nor_ptr);
+
+        //const double* v10_ptr = v10 + i * 3;
+        //const double* v21_ptr = v21 + i * 3;
+        //const double* v02_ptr = v02 + i * 3;
+        //const double* nor_ptr = nor + i * 3;
+        //const double* c_v10_nor_ptr = c_v10_nor + i * 3;
+        //const double* c_v21_nor_ptr = c_v21_nor + i * 3;
+        //const double* c_v02_nor_ptr = c_v02_nor + i * 3;
+        //double inv_dot2_v10_val = inv_dot2_v10[i];
+        //double inv_dot2_v21_val = inv_dot2_v21[i];
+        //double inv_dot2_v02_val = inv_dot2_v02[i];
+        //double inv_dot2_nor_val = inv_dot2_nor[i];
+
+        double p0[3], p1[3], p2[3];
         p0[0] = point_ptr[0] - triangle_ptr[0];
         p0[1] = point_ptr[1] - triangle_ptr[1];
         p0[2] = point_ptr[2] - triangle_ptr[2];
@@ -435,7 +435,7 @@ __global__ void kernel_mesh2sdf_quad(
         p2[1] = point_ptr[1] - triangle_ptr[7];
         p2[2] = point_ptr[2] - triangle_ptr[8];
         /*
-        float3 p0, p1, p2;
+        double3 p0, p1, p2;
         p0.x = point_ptr[0] - triangle_ptr[0];
         p0.y = point_ptr[1] - triangle_ptr[1];
         p0.z = point_ptr[2] - triangle_ptr[2];
@@ -448,17 +448,17 @@ __global__ void kernel_mesh2sdf_quad(
         */
         // if the normal vector is zero, the triangle is degenerative.
         if (nor_ptr[0] != 0.0f || nor_ptr[1] != 0.0f || nor_ptr[2] != 0.0f) {
-                
-            float s1 = sign(dot(c_v10_nor_ptr, p0));
-            float s2 = sign(dot(c_v21_nor_ptr, p1));
-            float s3 = sign(dot(c_v02_nor_ptr, p2));
-            
-            float distsq;
+
+            double s1 = sign(dot(c_v10_nor_ptr, p0));
+            double s2 = sign(dot(c_v21_nor_ptr, p1));
+            double s3 = sign(dot(c_v02_nor_ptr, p2));
+
+            double distsq;
             if ((s1+s2+s3) < 2.0f) {
                 // Edge dist
-                float ed1 = d2axmb(v10_ptr, clamp(dot(v10_ptr,p0)*inv_dot2_v10_val,0.0f,1.0f), p0);
-                float ed2 = d2axmb(v21_ptr, clamp(dot(v21_ptr,p1)*inv_dot2_v21_val,0.0f,1.0f), p1);
-                float ed3 = d2axmb(v02_ptr, clamp(dot(v02_ptr,p2)*inv_dot2_v02_val,0.0f,1.0f), p2);
+                double ed1 = d2axmb(v10_ptr, clamp(dot(v10_ptr,p0)*inv_dot2_v10_val,0.0f,1.0f), p0);
+                double ed2 = d2axmb(v21_ptr, clamp(dot(v21_ptr,p1)*inv_dot2_v21_val,0.0f,1.0f), p1);
+                double ed3 = d2axmb(v02_ptr, clamp(dot(v02_ptr,p2)*inv_dot2_v02_val,0.0f,1.0f), p2);
                 distsq = fminf(ed1, fminf(ed2, ed3));
             } else {
                 // Face dist
@@ -470,16 +470,16 @@ __global__ void kernel_mesh2sdf_quad(
             //distsq = fabs(distsq);
             mindistsq = fminf(mindistsq, distsq);
         }
-        
+
         // Calculate inside/outside
         // With triangle-ray intersection
         // center: point_ptr
         // direction: -point_ptr
         // Triangle: triangle_ptr [x y z x y z x y z]
-        //float3 tvec;
-        //float3 edge1, edge2;
-        float3 edge2;
-        float* edge1 = v10_ptr;
+        //double3 tvec;
+        //double3 edge1, edge2;
+        double3 edge2;
+        double* edge1 = v10_ptr;
         /*
         edge1.x = triangle_ptr[3] - triangle_ptr[0];
         edge1.y = triangle_ptr[4] - triangle_ptr[1];
@@ -494,9 +494,9 @@ __global__ void kernel_mesh2sdf_quad(
         edge2.x = -v02_ptr[0];
         edge2.y = -v02_ptr[1];
         edge2.z = -v02_ptr[2];
-        
-        float3 dir;
-        
+
+        double3 dir;
+
         // test 4 directions
         // more directions:
         // (1 0 0), (0 1 0), (0 0 1)
@@ -508,43 +508,43 @@ __global__ void kernel_mesh2sdf_quad(
             dir.y = stab_dir_table[i][1];
             dir.z = stab_dir_table[i][2];
 
-            float3 pvec = cross(dir, edge2);
+            double3 pvec = cross(dir, edge2);
             //pvec = normalize(pvec);
-            float det = dot(edge1, pvec);
-            //float3 pvec = cross(point_ptr, v02_ptr); // Both have negative direction, result have correct direction
-            //float det = dot(v10_ptr, pvec);
-            
-            
+            double det = dot(edge1, pvec);
+            //double3 pvec = cross(point_ptr, v02_ptr); // Both have negative direction, result have correct direction
+            //double det = dot(v10_ptr, pvec);
+
+
             if (det > -1e-8 && det < 1e-8) // No intersection at all
                 continue;
-            float inv_det = 1.0f / det;
-            
-            float3 tvec;
+            double inv_det = 1.0f / det;
+
+            double3 tvec;
             tvec.x = point_ptr[0] - triangle_ptr[0];
             tvec.y = point_ptr[1] - triangle_ptr[1];
             tvec.z = point_ptr[2] - triangle_ptr[2];
-            
-            
+
+
             // tvec = orig - vert0
             //tvec = p0;
             // Calculate barycentric uvs
-            //float u = dot(p0, pvec) * inv_det;
-            float u = dot(tvec, pvec) * inv_det;
+            //double u = dot(p0, pvec) * inv_det;
+            double u = dot(tvec, pvec) * inv_det;
             if (u < 0.0f || u > 1.0f) { // u out of bound
                 continue;
             }
-            //float3 qvec = cross(p0, v10_ptr);
-            float3 qvec = cross(tvec, edge1);
-            
-            //float v = - dot(point_ptr, qvec) * inv_det;
-            float v = dot(dir, qvec) * inv_det;
+            //double3 qvec = cross(p0, v10_ptr);
+            double3 qvec = cross(tvec, edge1);
+
+            //double v = - dot(point_ptr, qvec) * inv_det;
+            double v = dot(dir, qvec) * inv_det;
             if (v < 0.0f || u + v > 1.0f) {
                 continue;
             }
-            
+
             // Ray intersects triangle
-            //float t = - dot(v02_ptr, qvec) * inv_det;
-            float t = dot(edge2, qvec) * inv_det;
+            //double t = - dot(v02_ptr, qvec) * inv_det;
+            double t = dot(edge2, qvec) * inv_det;
 
             if (t >= 0.0f)
                 pos_intersect[i] = 1;
@@ -555,11 +555,11 @@ __global__ void kernel_mesh2sdf_quad(
             //}
         }
     }
-    
-    //float mindist = sqrtf(mindistsq);
+
+    //double mindist = sqrtf(mindistsq);
     //output_base[pindex] = mindist;
     output_base[pindex] = mindistsq;
-    
+
     /*
     int outside = 0;
     for (int i=0; i<13; i++) {
@@ -579,23 +579,282 @@ __global__ void kernel_mesh2sdf_quad(
     //    printf("%d\n", num_intersect);
     //}
     //output[index] = sqrtf(mindistsq) * mindistsign;
-    
+
+}
+
+__global__ void kernel_mesh2sdf_triangle_quad(
+    const int num_points,
+    const double* __restrict__ points,
+    const int num_triangles,
+    const double* __restrict__ mesh,
+    double* __restrict__ output,
+    double* __restrict__ output_triangle,
+    uint8_t* __restrict__ raystab_results) {
+    const int split_factor = SPLIT_FACTOR;
+    int index = blockIdx.x * blockDim.x + threadIdx.x;
+
+    int pindex = index % num_points;
+    int rindex = index / num_points;
+
+    if (rindex >= split_factor) {
+        return;
+    }
+
+    int tranksize = (num_triangles + split_factor - 1) / split_factor;
+    int tstart = tranksize * rindex;
+    int tend = min(tstart + tranksize, num_triangles);
+
+    // SPLIT_FACTOR, num_points, 13, 2
+    uint8_t* raystab_cache_base = raystab_results + rindex * num_points * 13 * 2 + pindex * 13 * 2;
+    // SPLIT_FACTOR, num_points
+    double* output_base = output + rindex * num_points;
+    double* output_triangle_base = output_triangle + rindex * num_points;
+
+    const double* point_ptr = points + pindex * 3;
+    double mindistsq = INFINITY;
+    double closest_triangle_idx = -1;
+    //int num_intersect = 0;
+    //int pos_intersect[13] = {0,0,0,0,0,0,0,0,0,0,0,0,0};
+    //int neg_intersect[13] = {0,0,0,0,0,0,0,0,0,0,0,0,0};
+    uint8_t* pos_intersect = raystab_cache_base;
+    uint8_t* neg_intersect = raystab_cache_base + 13;
+
+    double stab_dir_table[13][3] = { {1.0f, 0.0f, 0.0f},
+                                    {0.0f, 1.0f, 0.0f},
+                                    {0.0f, 0.0f, 1.0f},
+                                    {0.0f, 0.707106781f, 0.707106781f},
+                                    {0.707106781f, 0.0f, 0.707106781f},
+                                    {0.707106781f, 0.707106781f, 0.0f},
+                                    {0.0f, 0.707106781f, -0.707106781f},
+                                    {0.707106781f, 0.0f, -0.707106781f},
+                                    {0.707106781f, -0.707106781f, 0.0f},
+                                    {0.577350269f, 0.577350269f, 0.577350269f},
+                                    {-0.577350269f, 0.577350269f, 0.577350269f},
+                                    {0.577350269f, -0.577350269f, 0.577350269f},
+                                    {0.577350269f, 0.577350269f, -0.577350269f}};
+
+    // Loop over each triangle
+    //for (int i=0; i<num_triangles; i++) {
+    for (int i=tstart; i<tend; i++) {
+
+        const double* triangle_ptr = mesh + i * 9;
+        double v10_ptr[3];
+        double v21_ptr[3];
+        double v02_ptr[3];
+        v10_ptr[0] = triangle_ptr[3] - triangle_ptr[0];
+        v10_ptr[1] = triangle_ptr[4] - triangle_ptr[1];
+        v10_ptr[2] = triangle_ptr[5] - triangle_ptr[2];
+        v21_ptr[0] = triangle_ptr[6] - triangle_ptr[3];
+        v21_ptr[1] = triangle_ptr[7] - triangle_ptr[4];
+        v21_ptr[2] = triangle_ptr[8] - triangle_ptr[5];
+        v02_ptr[0] = triangle_ptr[0] - triangle_ptr[6];
+        v02_ptr[1] = triangle_ptr[1] - triangle_ptr[7];
+        v02_ptr[2] = triangle_ptr[2] - triangle_ptr[8];
+
+        double nor_ptr[3];
+        cross(v10_ptr, v02_ptr, nor_ptr);
+
+        double c_v10_nor_ptr[3];
+        double c_v21_nor_ptr[3];
+        double c_v02_nor_ptr[3];
+        cross(v10_ptr, nor_ptr, c_v10_nor_ptr);
+        cross(v21_ptr, nor_ptr, c_v21_nor_ptr);
+        cross(v02_ptr, nor_ptr, c_v02_nor_ptr);
+
+        double inv_dot2_v10_val = idot2(v10_ptr);
+        double inv_dot2_v21_val = idot2(v21_ptr);
+        double inv_dot2_v02_val = idot2(v02_ptr);
+        double inv_dot2_nor_val = idot2(nor_ptr);
+
+        //const double* v10_ptr = v10 + i * 3;
+        //const double* v21_ptr = v21 + i * 3;
+        //const double* v02_ptr = v02 + i * 3;
+        //const double* nor_ptr = nor + i * 3;
+        //const double* c_v10_nor_ptr = c_v10_nor + i * 3;
+        //const double* c_v21_nor_ptr = c_v21_nor + i * 3;
+        //const double* c_v02_nor_ptr = c_v02_nor + i * 3;
+        //double inv_dot2_v10_val = inv_dot2_v10[i];
+        //double inv_dot2_v21_val = inv_dot2_v21[i];
+        //double inv_dot2_v02_val = inv_dot2_v02[i];
+        //double inv_dot2_nor_val = inv_dot2_nor[i];
+
+        double p0[3], p1[3], p2[3];
+        p0[0] = point_ptr[0] - triangle_ptr[0];
+        p0[1] = point_ptr[1] - triangle_ptr[1];
+        p0[2] = point_ptr[2] - triangle_ptr[2];
+        p1[0] = point_ptr[0] - triangle_ptr[3];
+        p1[1] = point_ptr[1] - triangle_ptr[4];
+        p1[2] = point_ptr[2] - triangle_ptr[5];
+        p2[0] = point_ptr[0] - triangle_ptr[6];
+        p2[1] = point_ptr[1] - triangle_ptr[7];
+        p2[2] = point_ptr[2] - triangle_ptr[8];
+        /*
+        double3 p0, p1, p2;
+        p0.x = point_ptr[0] - triangle_ptr[0];
+        p0.y = point_ptr[1] - triangle_ptr[1];
+        p0.z = point_ptr[2] - triangle_ptr[2];
+        p1.x = point_ptr[0] - triangle_ptr[3];
+        p1.y = point_ptr[1] - triangle_ptr[4];
+        p1.z = point_ptr[2] - triangle_ptr[5];
+        p2.x = point_ptr[0] - triangle_ptr[6];
+        p2.y = point_ptr[1] - triangle_ptr[7];
+        p2.z = point_ptr[2] - triangle_ptr[8];
+        */
+        // if the normal vector is zero, the triangle is degenerative.
+        if (nor_ptr[0] != 0.0f || nor_ptr[1] != 0.0f || nor_ptr[2] != 0.0f) {
+
+            double s1 = sign(dot(c_v10_nor_ptr, p0));
+            double s2 = sign(dot(c_v21_nor_ptr, p1));
+            double s3 = sign(dot(c_v02_nor_ptr, p2));
+
+            double distsq;
+            if ((s1+s2+s3) < 2.0f) {
+                // Edge dist
+                double ed1 = d2axmb(v10_ptr, clamp(dot(v10_ptr,p0)*inv_dot2_v10_val,0.0f,1.0f), p0);
+                double ed2 = d2axmb(v21_ptr, clamp(dot(v21_ptr,p1)*inv_dot2_v21_val,0.0f,1.0f), p1);
+                double ed3 = d2axmb(v02_ptr, clamp(dot(v02_ptr,p2)*inv_dot2_v02_val,0.0f,1.0f), p2);
+                distsq = fminf(ed1, fminf(ed2, ed3));
+            } else {
+                // Face dist
+                distsq = dot(nor_ptr, p0) * dot(nor_ptr, p0) * inv_dot2_nor_val;
+            }
+            if (distsq < 0.0f) {
+                distsq = 0.0f;
+            }
+            //distsq = fabs(distsq);
+            if (mindistsq > distsq){
+                mindistsq = distsq;
+                closest_triangle_idx = i;
+            }
+            //mindistsq = fminf(mindistsq, distsq);
+        }
+
+        // Calculate inside/outside
+        // With triangle-ray intersection
+        // center: point_ptr
+        // direction: -point_ptr
+        // Triangle: triangle_ptr [x y z x y z x y z]
+        //double3 tvec;
+        //double3 edge1, edge2;
+        double3 edge2;
+        double* edge1 = v10_ptr;
+        /*
+        edge1.x = triangle_ptr[3] - triangle_ptr[0];
+        edge1.y = triangle_ptr[4] - triangle_ptr[1];
+        edge1.z = triangle_ptr[5] - triangle_ptr[2];
+        edge2.x = triangle_ptr[6] - triangle_ptr[0];
+        edge2.y = triangle_ptr[7] - triangle_ptr[1];
+        edge2.z = triangle_ptr[8] - triangle_ptr[2];
+        */
+        //edge1.x = v10_ptr[0];
+        //edge1.y = v10_ptr[1];
+        //edge1.z = v10_ptr[2];
+        edge2.x = -v02_ptr[0];
+        edge2.y = -v02_ptr[1];
+        edge2.z = -v02_ptr[2];
+
+        double3 dir;
+
+        // test 4 directions
+        // more directions:
+        // (1 0 0), (0 1 0), (0 0 1)
+        // (1 1 0), (1 0 1), (0 1 1)
+        // (1 -1 0), (1 0 -1), (0 1 -1)
+        // (1 1 1), (1 1 -1), (1 -1 1), (-1 1 1)
+        for (int i=0; i<13; i++) {
+            dir.x = stab_dir_table[i][0];
+            dir.y = stab_dir_table[i][1];
+            dir.z = stab_dir_table[i][2];
+
+            double3 pvec = cross(dir, edge2);
+            //pvec = normalize(pvec);
+            double det = dot(edge1, pvec);
+            //double3 pvec = cross(point_ptr, v02_ptr); // Both have negative direction, result have correct direction
+            //double det = dot(v10_ptr, pvec);
+
+
+            if (det > -1e-8 && det < 1e-8) // No intersection at all
+                continue;
+            double inv_det = 1.0f / det;
+
+            double3 tvec;
+            tvec.x = point_ptr[0] - triangle_ptr[0];
+            tvec.y = point_ptr[1] - triangle_ptr[1];
+            tvec.z = point_ptr[2] - triangle_ptr[2];
+
+
+            // tvec = orig - vert0
+            //tvec = p0;
+            // Calculate barycentric uvs
+            //double u = dot(p0, pvec) * inv_det;
+            double u = dot(tvec, pvec) * inv_det;
+            if (u < 0.0f || u > 1.0f) { // u out of bound
+                continue;
+            }
+            //double3 qvec = cross(p0, v10_ptr);
+            double3 qvec = cross(tvec, edge1);
+
+            //double v = - dot(point_ptr, qvec) * inv_det;
+            double v = dot(dir, qvec) * inv_det;
+            if (v < 0.0f || u + v > 1.0f) {
+                continue;
+            }
+
+            // Ray intersects triangle
+            //double t = - dot(v02_ptr, qvec) * inv_det;
+            double t = dot(edge2, qvec) * inv_det;
+
+            if (t >= 0.0f)
+                pos_intersect[i] = 1;
+            else
+                neg_intersect[i] = 1;
+            //if (t >= 0.0f) {
+            //    num_intersect++;
+            //}
+        }
+    }
+
+    //double mindist = sqrtf(mindistsq);
+    //output_base[pindex] = mindist;
+    output_base[pindex] = mindistsq;
+    output_triangle_base[pindex] = closest_triangle_idx;
+
+    /*
+    int outside = 0;
+    for (int i=0; i<13; i++) {
+        if (pos_intersect[i] == 0 || neg_intersect[i] == 0) { // if outside
+            outside = 1;
+            break;
+        }
+    }
+    if (!outside) {
+        mindist = -1e-6f;
+    }*/
+    //if (pos_intersect && neg_intersect) {
+    //    mindist = -1e-6f;
+    //}
+    //if (num_intersect % 2 == 1) {
+    //    mindist *= -1.0f;
+    //    printf("%d\n", num_intersect);
+    //}
+    //output[index] = sqrtf(mindistsq) * mindistsign;
+
 }
 
 __global__ void kernel_quad_aggr(
-    const int num_points, 
-    const int num_triangles, 
-    const float* __restrict__ output,
+    const int num_points,
+    const int num_triangles,
+    const double* __restrict__ output,
     const uint8_t* __restrict__ raystab_results,
-    float* __restrict__ final_output) {
-    
+    double* __restrict__ final_output) {
+
     const int split_factor = SPLIT_FACTOR;
     int index = blockIdx.x * blockDim.x + threadIdx.x;
-    
+
     if (index >= num_points) {
         return;
     }
-    
+
     // for each point in 3D space
     int outside = 0;
     for (int i=0; i<13; i++) {
@@ -613,11 +872,11 @@ __global__ void kernel_quad_aggr(
             break;
         }
     }
-    
-    float mindist;
-    float mindistsq = INFINITY;
+
+    double mindist;
+    double mindistsq = INFINITY;
     for (int s=0; s<SPLIT_FACTOR; s++) {
-        const float* output_base = output + s * num_points;
+        const double* output_base = output + s * num_points;
         mindistsq = fminf(mindistsq, output_base[index]);
     }
     if (mindistsq < 0.0f) {
@@ -627,12 +886,12 @@ __global__ void kernel_quad_aggr(
     if (!outside) {
         mindist = -mindist;
     }
-    
+
     /*
     if (outside) {
-        float mindistsq = INFINITY;
+        double mindistsq = INFINITY;
         for (int s=0; s<SPLIT_FACTOR; s++) {
-            const float* output_base = output + s * num_points;
+            const double* output_base = output + s * num_points;
             mindistsq = fminf(mindistsq, output_base[index]);
         }
         mindist = sqrtf(mindistsq);
@@ -642,52 +901,122 @@ __global__ void kernel_quad_aggr(
     final_output[index] = mindist;
 }
 
-__global__ void kernel_triangle2sdf_forward(
-    const int num_points, 
-    const float* __restrict__ points,
-    const int num_triangles, 
-    const float* __restrict__ vertices,
-    const float* __restrict__ v10,
-    const float* __restrict__ v21,
-    const float* __restrict__ v02,
-    const float* __restrict__ nor,
-    const float* __restrict__ c_v10_nor,
-    const float* __restrict__ c_v21_nor,
-    const float* __restrict__ c_v02_nor,
-    const float* __restrict__ inv_dot2_v10,
-    const float* __restrict__ inv_dot2_v21,
-    const float* __restrict__ inv_dot2_v02,
-    const float* __restrict__ inv_dot2_nor,
-    bool* __restrict__ out_isfacedist,
-    int* __restrict__ out_nearesttriangle,
-    float* __restrict__ output) {
-    
+__global__ void kernel_mesh2sdf_triangle_quad_aggr(
+    const int num_points,
+    const int num_triangles,
+    const double* __restrict__ output,
+    const double* __restrict__ output_triangle,
+    const uint8_t* __restrict__ raystab_results,
+    double* __restrict__ final_output,
+    double* __restrict__ final_output_triangle) {
+
+    const int split_factor = SPLIT_FACTOR;
     int index = blockIdx.x * blockDim.x + threadIdx.x;
-    
+
     if (index >= num_points) {
         return;
     }
-    
-    const float* point_ptr = points + index * 3;
-    float mindistsq = INFINITY;
+
+    // for each point in 3D space
+    int outside = 0;
+    for (int i=0; i<13; i++) {
+        uint8_t pos_aggr = 0;
+        uint8_t neg_aggr = 0;
+        for (int s=0; s<SPLIT_FACTOR; s++) {
+            const uint8_t* raystab_cache_base = raystab_results + s * num_points * 13 * 2 + index * 13 * 2;
+            const uint8_t* pos_intersect = raystab_cache_base;
+            const uint8_t* neg_intersect = raystab_cache_base + 13;
+            pos_aggr = pos_aggr | pos_intersect[i];
+            neg_aggr = neg_aggr | neg_intersect[i];
+        }
+        if (pos_aggr == 0 || neg_aggr == 0) { // if outside
+            outside = 1;
+            break;
+        }
+    }
+
+    double mindist;
+    double mindistsq = INFINITY;
+    double closest_triangle_idx = -1;
+    for (int s=0; s<SPLIT_FACTOR; s++) {
+        const double* output_base = output + s * num_points;
+        const double* output_triangle_base = output_triangle + s * num_points;
+
+        if (mindistsq > output_base[index]){
+            mindistsq = output_base[index];
+            closest_triangle_idx = output_triangle_base[index];
+        }
+        //mindistsq = fminf(mindistsq, output_base[index]);
+    }
+    if (mindistsq < 0.0f) {
+        mindistsq = 0.0f;
+    }
+    mindist = sqrtf(mindistsq);
+    if (!outside) {
+        mindist = -mindist;
+    }
+
+    /*
+    if (outside) {
+        double mindistsq = INFINITY;
+        for (int s=0; s<SPLIT_FACTOR; s++) {
+            const double* output_base = output + s * num_points;
+            mindistsq = fminf(mindistsq, output_base[index]);
+        }
+        mindist = sqrtf(mindistsq);
+    } else {
+        mindist = -1e-6f;
+    }*/
+    final_output[index] = mindist;
+    final_output_triangle[index] = closest_triangle_idx;
+}
+
+__global__ void kernel_triangle2sdf_forward(
+    const int num_points,
+    const double* __restrict__ points,
+    const int num_triangles,
+    const double* __restrict__ vertices,
+    const double* __restrict__ v10,
+    const double* __restrict__ v21,
+    const double* __restrict__ v02,
+    const double* __restrict__ nor,
+    const double* __restrict__ c_v10_nor,
+    const double* __restrict__ c_v21_nor,
+    const double* __restrict__ c_v02_nor,
+    const double* __restrict__ inv_dot2_v10,
+    const double* __restrict__ inv_dot2_v21,
+    const double* __restrict__ inv_dot2_v02,
+    const double* __restrict__ inv_dot2_nor,
+    bool* __restrict__ out_isfacedist,
+    int* __restrict__ out_nearesttriangle,
+    double* __restrict__ output) {
+
+    int index = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (index >= num_points) {
+        return;
+    }
+
+    const double* point_ptr = points + index * 3;
+    double mindistsq = INFINITY;
     int nearest_triangle_id = -1;
     bool is_face_dist = false;
     // Loop over each triangle
     for (int i=0; i<num_triangles; i++) {
-        const float* triangle_ptr = vertices + i * 9;
-        const float* v10_ptr = v10 + i * 3;
-        const float* v21_ptr = v21 + i * 3;
-        const float* v02_ptr = v02 + i * 3;
-        const float* nor_ptr = nor + i * 3;
-        const float* c_v10_nor_ptr = c_v10_nor + i * 3;
-        const float* c_v21_nor_ptr = c_v21_nor + i * 3;
-        const float* c_v02_nor_ptr = c_v02_nor + i * 3;
-        float inv_dot2_v10_val = inv_dot2_v10[i];
-        float inv_dot2_v21_val = inv_dot2_v21[i];
-        float inv_dot2_v02_val = inv_dot2_v02[i];
-        float inv_dot2_nor_val = inv_dot2_nor[i];
+        const double* triangle_ptr = vertices + i * 9;
+        const double* v10_ptr = v10 + i * 3;
+        const double* v21_ptr = v21 + i * 3;
+        const double* v02_ptr = v02 + i * 3;
+        const double* nor_ptr = nor + i * 3;
+        const double* c_v10_nor_ptr = c_v10_nor + i * 3;
+        const double* c_v21_nor_ptr = c_v21_nor + i * 3;
+        const double* c_v02_nor_ptr = c_v02_nor + i * 3;
+        double inv_dot2_v10_val = inv_dot2_v10[i];
+        double inv_dot2_v21_val = inv_dot2_v21[i];
+        double inv_dot2_v02_val = inv_dot2_v02[i];
+        double inv_dot2_nor_val = inv_dot2_nor[i];
 
-        float3 p0, p1, p2;
+        double3 p0, p1, p2;
         p0.x = point_ptr[0] - triangle_ptr[0];
         p0.y = point_ptr[1] - triangle_ptr[1];
         p0.z = point_ptr[2] - triangle_ptr[2];
@@ -697,23 +1026,23 @@ __global__ void kernel_triangle2sdf_forward(
         p2.x = point_ptr[0] - triangle_ptr[6];
         p2.y = point_ptr[1] - triangle_ptr[7];
         p2.z = point_ptr[2] - triangle_ptr[8];
-        
+
         // if the normal vector is zero, the triangle is degenerative.
         if (nor_ptr[0] != 0.0f || nor_ptr[1] != 0.0f || nor_ptr[2] != 0.0f) {
-            
-            float s1 = sign(dot(c_v10_nor_ptr, p0));
-            float s2 = sign(dot(c_v21_nor_ptr, p1));
-            float s3 = sign(dot(c_v02_nor_ptr, p2));
-            
-            float distsq;
+
+            double s1 = sign(dot(c_v10_nor_ptr, p0));
+            double s2 = sign(dot(c_v21_nor_ptr, p1));
+            double s3 = sign(dot(c_v02_nor_ptr, p2));
+
+            double distsq;
             bool face_dist;
             if ((s1+s2+s3) < 2.0f) {
             //if (0) {
                 // Edge dist
                 face_dist = false;
-                float ed1 = d2axmb(v10_ptr, clamp(dot(v10_ptr,p0)*inv_dot2_v10_val,0.0f,1.0f), p0);
-                float ed2 = d2axmb(v21_ptr, clamp(dot(v21_ptr,p1)*inv_dot2_v21_val,0.0f,1.0f), p1);
-                float ed3 = d2axmb(v02_ptr, clamp(dot(v02_ptr,p2)*inv_dot2_v02_val,0.0f,1.0f), p2);
+                double ed1 = d2axmb(v10_ptr, clamp(dot(v10_ptr,p0)*inv_dot2_v10_val,0.0f,1.0f), p0);
+                double ed2 = d2axmb(v21_ptr, clamp(dot(v21_ptr,p1)*inv_dot2_v21_val,0.0f,1.0f), p1);
+                double ed3 = d2axmb(v02_ptr, clamp(dot(v02_ptr,p2)*inv_dot2_v02_val,0.0f,1.0f), p2);
                 distsq = fminf(ed1, fminf(ed2, ed3));
             } else {
                 // Face dist
@@ -732,8 +1061,8 @@ __global__ void kernel_triangle2sdf_forward(
             //mindistsq = fminf(mindistsq, distsq);
         }
     }
-    
-    float mindist = sqrtf(mindistsq);
+
+    double mindist = sqrtf(mindistsq);
     output[index] = mindist;
     out_nearesttriangle[index] = nearest_triangle_id;
     out_isfacedist[index] = is_face_dist;
@@ -744,21 +1073,21 @@ __global__ void kernel_triangle2sdf_forward(
 // Test if one of the vertex of a triangle is outside the shape.
 // Failure case: When all of the three vertices are inside the shape but a portion of the face is outside.
 __global__ void kernel_trimmesh(
-    const int num_triangles, 
-    const float* __restrict__ mesh,
+    const int num_triangles,
+    const double* __restrict__ mesh,
     bool* __restrict__ output) {
-    
+
     int index = blockIdx.x * blockDim.x + threadIdx.x;
-    
+
     if (index >= num_triangles) {
         return;
     }
-    
+
     // (1 0 0), (0 1 0), (0 0 1)
     // (1 1 0), (1 0 1), (0 1 1)
     // (1 -1 0), (1 0 -1), (0 1 -1)
     // (1 1 1), (1 1 -1), (1 -1 1), (-1 1 1)
-    float raystubdirs[13][3] = {{1.0f, 0.0f, 0.0f},
+    double raystubdirs[13][3] = {{1.0f, 0.0f, 0.0f},
                                 {0.0f, 1.0f, 0.0f},
                                 {0.0f, 0.0f, 1.0f},
                                 {0.0f, 0.707106781f, 0.707106781f},
@@ -771,12 +1100,12 @@ __global__ void kernel_trimmesh(
                                 {-0.577350269f, 0.577350269f, 0.577350269f},
                                 {0.577350269f, -0.577350269f, 0.577350269f},
                                 {0.577350269f, 0.577350269f, -0.577350269f}};
-    
-    const float* vtx_ptr = mesh + index * 9; // x y z
+
+    const double* vtx_ptr = mesh + index * 9; // x y z
     // for each vertex
     for (int p=6; p>=0; p--) {
-        //const float* vtx_ptr = mesh + index * 9 + p * 3; // x y z
-        float3 vtx;
+        //const double* vtx_ptr = mesh + index * 9 + p * 3; // x y z
+        double3 vtx;
         if (p == 6) {           // Center
             vtx.x = (vtx_ptr[0] + vtx_ptr[3] + vtx_ptr[6]) / 3.0f;
             vtx.y = (vtx_ptr[1] + vtx_ptr[4] + vtx_ptr[7]) / 3.0f;
@@ -793,7 +1122,7 @@ __global__ void kernel_trimmesh(
             vtx.y = vtx_ptr[p1*3+1];
             vtx.z = vtx_ptr[p1*3+2];
         }
-        
+
         int pos_intersect[13] = {};
         int neg_intersect[13] = {};
         // for each triangle
@@ -801,52 +1130,52 @@ __global__ void kernel_trimmesh(
             //if (t == index) {
             //    continue;
             //}
-            const float* triangle_ptr = mesh + t * 9;
-            
-            float3 edge1, edge2;
+            const double* triangle_ptr = mesh + t * 9;
+
+            double3 edge1, edge2;
             edge1.x = triangle_ptr[3] - triangle_ptr[0];
             edge1.y = triangle_ptr[4] - triangle_ptr[1];
             edge1.z = triangle_ptr[5] - triangle_ptr[2];
             edge2.x = triangle_ptr[6] - triangle_ptr[0];
             edge2.y = triangle_ptr[7] - triangle_ptr[1];
             edge2.z = triangle_ptr[8] - triangle_ptr[2];
-            
+
             // test directions:
-            float3 dir;
+            double3 dir;
             for (int i=0; i<13; i++) {
                 dir.x = raystubdirs[i][0];
                 dir.y = raystubdirs[i][1];
                 dir.z = raystubdirs[i][2];
-                
-                float3 pvec = cross(dir, edge2);
-                float det = dot(edge1, pvec);
-                
+
+                double3 pvec = cross(dir, edge2);
+                double det = dot(edge1, pvec);
+
                 if (det > -1e-8 && det < 1e-8) // No intersection at all
                     continue;
-                float inv_det = 1.0f / det;
-                
-                float3 tvec;
+                double inv_det = 1.0f / det;
+
+                double3 tvec;
                 //tvec.x = vtx_ptr[0] - triangle_ptr[0];
                 //tvec.y = vtx_ptr[1] - triangle_ptr[1];
                 //tvec.z = vtx_ptr[2] - triangle_ptr[2];
                 tvec.x = vtx.x - triangle_ptr[0];
                 tvec.y = vtx.y - triangle_ptr[1];
                 tvec.z = vtx.z - triangle_ptr[2];
-                
+
                 // Calculate barycentric uvs
-                float u = dot(tvec, pvec) * inv_det;
+                double u = dot(tvec, pvec) * inv_det;
                 if (u <= 0.0f || u >= 1.0f) { // u out of bound
                     continue;
                 }
-                float3 qvec = cross(tvec, edge1);
-                
-                float v = dot(dir, qvec) * inv_det;
+                double3 qvec = cross(tvec, edge1);
+
+                double v = dot(dir, qvec) * inv_det;
                 if (v <= 0.0f || u + v >= 1.0f) {
                     continue;
                 }
-                
+
                 // Ray intersects triangle
-                float t = dot(edge2, qvec) * inv_det;
+                double t = dot(edge2, qvec) * inv_det;
 
                 if (t > 1e-4f)
                     pos_intersect[i] = 1;
@@ -856,7 +1185,7 @@ __global__ void kernel_trimmesh(
             // If there exist one ray that has no or only single sided intersection
             // The point is outside.
         }
-        
+
         // As long as one vertex is outside, the whole triangle is outside.
         for (int i=0; i<13; i++) {
             if (pos_intersect[i] == 0 || neg_intersect[i] == 0) { // if outside
@@ -865,7 +1194,7 @@ __global__ void kernel_trimmesh(
             }
         }
     }
-    
+
     // 1: fine. 0: trim it!
     output[index] = false;
 }
@@ -885,72 +1214,116 @@ std::vector<torch::Tensor> mesh2sdf_gpu(
     torch::Tensor& inv_dot2_v21,
     torch::Tensor& inv_dot2_v02,
     torch::Tensor& inv_dot2_nor ) {
-    
+
     // Step 1: create an empty tensor to store the output.
     int num_points = points.size(0);
-    torch::Tensor out_dist = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
-    
+    torch::Tensor out_dist = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCUDA));
+
     int num_triangles = mesh.size(0);
-    
+
     //printf("Hello, world!\nEvaluating %d points...\n", num_points);
-    
+
     // Step 2: for each point, find its distance to mesh
     // Assume all the arrays are contiguous.
     // <<<Dg, Db, Ns, S>>>
     //kernel_mesh2sdf<<< (num_points + 256 - 1)/256, 256, 0, at::cuda::getCurrentCUDAStream() >>>(
     kernel_mesh2sdf<<< (num_points + CUDA_NUM_THREADS - 1)/CUDA_NUM_THREADS, CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream() >>>(
           num_points,
-          points.data<float>(), 
+          points.data<double>(),
           num_triangles,
-          mesh.data<float>(), 
-          v10.data<float>(), 
-          v21.data<float>(), 
-          v02.data<float>(), 
-          nor.data<float>(), 
-          c_v10_nor.data<float>(), 
-          c_v21_nor.data<float>(), 
-          c_v02_nor.data<float>(), 
-          inv_dot2_v10.data<float>(), 
-          inv_dot2_v21.data<float>(), 
-          inv_dot2_v02.data<float>(), 
-          inv_dot2_nor.data<float>(),
-          out_dist.data<float>());
-    
+          mesh.data<double>(),
+          v10.data<double>(),
+          v21.data<double>(),
+          v02.data<double>(),
+          nor.data<double>(),
+          c_v10_nor.data<double>(),
+          c_v21_nor.data<double>(),
+          c_v02_nor.data<double>(),
+          inv_dot2_v10.data<double>(),
+          inv_dot2_v21.data<double>(),
+          inv_dot2_v02.data<double>(),
+          inv_dot2_nor.data<double>(),
+          out_dist.data<double>());
+
     return {out_dist};
 }
 
 std::vector<torch::Tensor> mesh2sdf_gpu_fast_nopre(
     torch::Tensor& points,
     torch::Tensor& mesh ) {
-    
+
     // Step 1: create an empty tensor to store the output.
     int num_points = points.size(0);
-    torch::Tensor out_dist = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
-    torch::Tensor out_dist_temp = torch::empty({SPLIT_FACTOR, num_points}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
-    
+    torch::Tensor out_dist = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCUDA));
+    torch::Tensor out_dist_temp = torch::empty({SPLIT_FACTOR, num_points}, torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCUDA));
+
     int num_triangles = mesh.size(0);
-    
+
     torch::Tensor raystab_results = torch::zeros({SPLIT_FACTOR, num_points, 13, 2}, torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
-    
+
     // Step 2: for each point, find its distance to mesh
     // Assume all the arrays are contiguous.
     // <<<Dg, Db, Ns, S>>>
     kernel_mesh2sdf_quad<<< (num_points * SPLIT_FACTOR + CUDA_NUM_THREADS - 1)/CUDA_NUM_THREADS, CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream() >>>(
         num_points,
-        points.data<float>(), 
+        points.data<double>(),
         num_triangles,
-        mesh.data<float>(), 
-        out_dist_temp.data<float>(),
+        mesh.data<double>(),
+        out_dist_temp.data<double>(),
         raystab_results.data<uint8_t>());
-        
+
     kernel_quad_aggr<<<(num_points + CUDA_NUM_THREADS_AGGR - 1)/CUDA_NUM_THREADS_AGGR, CUDA_NUM_THREADS_AGGR, 0, at::cuda::getCurrentCUDAStream() >>>(
         num_points,
         num_triangles,
-        out_dist_temp.data<float>(),
+        out_dist_temp.data<double>(),
         raystab_results.data<uint8_t>(),
-        out_dist.data<float>());
-    
+        out_dist.data<double>());
+
     return {out_dist};
+}
+
+std::vector<torch::Tensor> mesh2sdf_triangle_gpu_fast_nopre(
+    torch::Tensor& points,
+    torch::Tensor& mesh ) {
+
+    // Step 1: create an empty tensor to store the output.
+    int num_points = points.size(0);
+    torch::Tensor out_dist = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCUDA));
+    torch::Tensor out_dist_temp = torch::empty({SPLIT_FACTOR, num_points}, torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCUDA));
+
+
+    torch::Tensor out_dist_triangle = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCUDA));
+    torch::Tensor out_dist_triangle_temp = torch::empty({SPLIT_FACTOR, num_points}, torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCUDA));
+
+    int num_triangles = mesh.size(0);
+
+    torch::Tensor raystab_results = torch::zeros({SPLIT_FACTOR, num_points, 13, 2}, torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
+
+    // Step 2: for each point, find its distance to mesh
+    // Assume all the arrays are contiguous.
+    // <<<Dg, Db, Ns, S>>>
+    kernel_mesh2sdf_triangle_quad<<< (num_points * SPLIT_FACTOR + CUDA_NUM_THREADS - 1)/CUDA_NUM_THREADS, CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream() >>>(
+        num_points,
+        points.data<double>(),
+        num_triangles,
+        mesh.data<double>(),
+        out_dist_temp.data<double>(),
+        out_dist_triangle_temp.data<double>(),
+        raystab_results.data<uint8_t>());
+
+    kernel_mesh2sdf_triangle_quad_aggr<<<(num_points + CUDA_NUM_THREADS_AGGR - 1)/CUDA_NUM_THREADS_AGGR, CUDA_NUM_THREADS_AGGR, 0, at::cuda::getCurrentCUDAStream() >>>(
+        num_points,
+        num_triangles,
+        out_dist_temp.data<double>(),
+        out_dist_triangle_temp.data<double>(),
+        raystab_results.data<uint8_t>(),
+        out_dist.data<double>(),
+        out_dist_triangle.data<double>());
+
+    torch::Tensor out = torch::cat({out_dist, out_dist_triangle}, /*dim=*/ 0);
+
+    // return {out_dist};
+    return {out};
 }
 
 
@@ -968,42 +1341,42 @@ std::vector<torch::Tensor> triangle2sdf_gpu_forward(
     torch::Tensor& inv_dot2_v21,
     torch::Tensor& inv_dot2_v02,
     torch::Tensor& inv_dot2_nor ) {
-    
+
     // Step 1: create an empty tensor to store the output.
     int num_points = points.size(0);
-    torch::Tensor out_dist = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
-    
+    torch::Tensor out_dist = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCUDA));
+
     torch::Tensor out_isfacedist = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kBool).device(torch::kCUDA));
-    
+
     torch::Tensor out_nearesttriangle = torch::empty({num_points}, torch::TensorOptions().dtype(torch::kInt32).device(torch::kCUDA));
-    
+
     int num_triangles = triangles.size(0);
-    
+
     //printf("Hello, world!\nEvaluating %d points...\n", num_points);
-    
+
     // Step 2: for each point, find its distance to mesh
     // Assume all the arrays are contiguous.
     // <<<Dg, Db, Ns, S>>>
     kernel_triangle2sdf_forward<<< (num_points + CUDA_NUM_THREADS - 1)/CUDA_NUM_THREADS, CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream() >>>(
           num_points,
-          points.data<float>(), 
+          points.data<double>(),
           num_triangles,
-          triangles.data<float>(), 
-          v10.data<float>(), 
-          v21.data<float>(), 
-          v02.data<float>(), 
-          nor.data<float>(), 
-          c_v10_nor.data<float>(), 
-          c_v21_nor.data<float>(), 
-          c_v02_nor.data<float>(), 
-          inv_dot2_v10.data<float>(), 
-          inv_dot2_v21.data<float>(), 
-          inv_dot2_v02.data<float>(), 
-          inv_dot2_nor.data<float>(),
+          triangles.data<double>(),
+          v10.data<double>(),
+          v21.data<double>(),
+          v02.data<double>(),
+          nor.data<double>(),
+          c_v10_nor.data<double>(),
+          c_v21_nor.data<double>(),
+          c_v02_nor.data<double>(),
+          inv_dot2_v10.data<double>(),
+          inv_dot2_v21.data<double>(),
+          inv_dot2_v02.data<double>(),
+          inv_dot2_nor.data<double>(),
           out_isfacedist.data<bool>(),
           out_nearesttriangle.data<int>(),
-          out_dist.data<float>());
-          
+          out_dist.data<double>());
+
     return {out_dist, out_isfacedist, out_nearesttriangle};
 }
 
@@ -1019,13 +1392,13 @@ torch::Tensor trimmesh_gpu( torch::Tensor& mesh ) {
     int num_triangles = mesh.size(0);
     //torch::Tensor out_isinside = torch::empty({num_triangles}, torch::TensorOptions().dtype(torch::kUInt8).device(torch::kCUDA));
     torch::Tensor out_isinside = torch::empty({num_triangles}, torch::TensorOptions().dtype(torch::kBool).device(torch::kCUDA));
-    
+
     // Step 2: for each point, find its distance to mesh
     // Assume all the arrays are contiguous.
     // <<<Dg, Db, Ns, S>>>
     kernel_trimmesh<<< (num_triangles + CUDA_NUM_THREADS - 1)/CUDA_NUM_THREADS, CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream() >>>(
           num_triangles,
-          mesh.data<float>(), 
+          mesh.data<double>(),
           out_isinside.data<bool>());
           
     return out_isinside;

--- a/wisp/csrc/external/mesh_to_sdf.cpp
+++ b/wisp/csrc/external/mesh_to_sdf.cpp
@@ -15,6 +15,10 @@ std::vector<at::Tensor> mesh2sdf_gpu_fast_nopre(
     at::Tensor& points,
     at::Tensor& mesh);
 
+std::vector<at::Tensor> mesh2sdf_triangle_gpu_fast_nopre(
+    at::Tensor& points,
+    at::Tensor& mesh);
+
 namespace wisp {
 
 std::vector<at::Tensor> mesh_to_sdf_cuda(
@@ -22,6 +26,16 @@ std::vector<at::Tensor> mesh_to_sdf_cuda(
     at::Tensor mesh) {
 #ifdef WITH_CUDA
   return mesh2sdf_gpu_fast_nopre(points, mesh);
+#else
+  AT_ERROR(__func__);
+#endif  // WITH_CUDA
+}
+
+std::vector<at::Tensor> mesh_to_sdf_triangle_cuda(
+    at::Tensor points,
+    at::Tensor mesh) {
+#ifdef WITH_CUDA
+  return mesh2sdf_triangle_gpu_fast_nopre(points, mesh);
 #else
   AT_ERROR(__func__);
 #endif  // WITH_CUDA

--- a/wisp/csrc/external/mesh_to_sdf.h
+++ b/wisp/csrc/external/mesh_to_sdf.h
@@ -21,4 +21,9 @@ std::vector<at::Tensor> mesh_to_sdf_cuda(
     at::Tensor points,
     at::Tensor mesh);
 
+std::vector<at::Tensor> mesh_to_sdf_triangle_cuda(
+    at::Tensor points,
+    at::Tensor mesh);
+
+
 }

--- a/wisp/ops/mesh/closest_point.py
+++ b/wisp/ops/mesh/closest_point.py
@@ -11,12 +11,149 @@
 
 import torch
 import numpy as np
+import wisp._C as _C
+
 
 def closest_point(
-    V : torch.Tensor, 
+    V : torch.Tensor,
     F : torch.Tensor,
-    points : torch.Tensor):
+    points : torch.Tensor,
+    split_size : int = 10**6):
+    """Computes points on mesh which is closest to the input points
 
-    assert False and "This function is not supported in the main branch. Please use ttakikawa/pysdf for this function."
+        Args:
+            V (torch.FloatTensor): [#V, 3] array of vertices
+            F (torch.LongTensor): [#F, 3] array of indices
+            points (torch.FloatTensor): [N, 3] array of points to sample
+            split_size (int): The batch at which the SDF will be computed. The kernel will break for too large
+                              batches; when in doubt use the default.
 
+        Returns:
+            (torch.FloatTensor): [N,] array of computed SDF values.
+            (torch.FloatTensor): [N, 3] array of closest points
+            (torch.FloatTensor): [N,] array of closest triangle indices
+        """
+    # If not using double, accumulated error can be large and degrade model performance.
+    V = V.double()
+    points = points.double()
+
+    mesh = V[F]
+    _points = torch.split(points, split_size)
+    split_len = len(_points)
+    dists = []
+    points = []
+    triangles_idx = []
+
+    for split_idx, _p in enumerate(_points):
+        print(f"Processing closest_point()... this may take up few minutes. [{split_idx + 1}/{split_len}]")
+
+        # gets sdf and triangle closest to the point _p
+        out = _C.external.mesh_to_sdf_triangle_cuda(_p.cuda().contiguous(), mesh.cuda().contiguous())[0]
+        out_len = out.shape[0]
+        half_len = int(out_len / 2)
+
+        dist = out[:half_len]  # distance to closest triangle (= sdf)
+        hit_tidx = out[half_len:].type(torch.long)  # closest triangle index
+        # calculate (point on the triangle) which is closest to point _p
+        hit_pts = closest_point_on_triangle(mesh.index_select(dim=0, index=hit_tidx).cuda().contiguous(), _p.cuda().contiguous())
+
+        dists.append(dist)
+        points.append(hit_pts)
+        triangles_idx.append(hit_tidx)
+
+    return torch.cat(dists), torch.cat(points), torch.cat(triangles_idx)
+
+
+def closest_point_on_triangle(triangles, points):
+    """
+    The implementation is based on closest_point function of trimesh library (https://github.com/mikedh/trimesh/blob/main/trimesh/triangles.py)
+    find mapping between n-th triangle and n-th point.
+    number of triangles and number of points should be same.
+
+    Args:
+        triangles: (n, 3, 3)
+        points: (n, 3)
+
+    Retunrs:
+        closest: (n, 3)
+          Point on each triangle closest to each point
+    """
+    device = points.device
+    dtype = points.dtype
+    result = torch.zeros_like(points).to(device)
+    remain = torch.ones(points.shape[0], dtype=bool).to(device)
+
+    ones = torch.ones(3, dtype=dtype).to(device)
+
+    a = triangles[:, 0, :]
+    b = triangles[:, 1, :]
+    c = triangles[:, 2, :]
+
+    ab = b - a
+    ac = c - a
+    ap = points - a
+
+    # * is dot product
+    # @ is matrix multiplication
+    d1 = (ab * ap) @ ones  # (10, 3) @ (3) = (10,)
+    d2 = (ac * ap) @ ones
+
+    # very small value
+    epsilon = torch.finfo(torch.float64).resolution
+
+    is_a = torch.logical_and(d1 < epsilon, d2 < epsilon)
+    if any(is_a):
+        result[is_a] = a[is_a]
+        remain[is_a] = False
+
+    bp = points - b
+    d3 = (ab * bp) @ ones
+    d4 = (ac * bp) @ ones
+
+    is_b = (d3 > -epsilon) & (d4 <= d3) & remain
+    if any(is_b):
+        result[is_b] = b[is_b]
+        remain[is_b] = False
+
+    vc = (d1 * d4) - (d3 * d2)
+    is_ab = ((vc < epsilon) &
+             (d1 > -epsilon) &
+             (d3 < epsilon) & remain)
+
+    if any(is_ab):
+        v = (d1[is_ab] / (d1[is_ab] - d3[is_ab])).reshape((-1, 1))
+        result[is_ab] = a[is_ab] + (v * ab[is_ab])
+        remain[is_ab] = False
+
+    cp = points - c
+    d5 = (ab * cp) @ ones
+    d6 = (ac * cp) @ ones
+    is_c = (d6 > -epsilon) & (d5 <= d6) & remain
+    if any(is_c):
+        result[is_c] = c[is_c]
+        remain[is_c] = False
+
+    vb = (d5 * d2) - (d1 * d6)
+    is_ac = (vb < epsilon) & (d2 > -epsilon) & (d6 < epsilon) & remain
+    if any(is_ac):
+        w = (d2[is_ac] / (d2[is_ac] - d6[is_ac])).reshape((-1, 1))
+        result[is_ac] = a[is_ac] + w * ac[is_ac]
+        remain[is_ac] = False
+
+    va = (d3 * d6) - (d5 * d4)
+    is_bc = ((va < epsilon) &
+             ((d4 - d3) > -epsilon) &
+             ((d5 - d6) > -epsilon) & remain)
+    if any(is_bc):
+        d43 = d4[is_bc] - d3[is_bc]
+        w = (d43 / (d43 + (d5[is_bc] - d6[is_bc]))).reshape((-1, 1))
+        result[is_bc] = b[is_bc] + w * (c[is_bc] - b[is_bc])
+        remain[is_bc] = False
+
+    if any(remain):
+        denom = 1.0 / (va[remain] + vb[remain] + vc[remain])
+        v = (vb[remain] * denom).reshape((-1, 1))
+        w = (vc[remain] * denom).reshape((-1, 1))
+        result[remain] = a[remain] + (ab[remain] * v) + (ac[remain] * w)
+    return result
 


### PR DESCRIPTION
Background:

Training SDF + texture model was not available because closest_point function wasn't implemented. (see #162)
To traing the SDF + texture model, I implement closest_point function.

Changes:

1. **Change all float variables** in wisp/csrc/external/mesh2sdf_kernel.cu **into double variables**. Previously, when using float variables, there were accumulated numerical errors on SDF and closest points' coordinates. (the numerical SDF errors even reaches 1.xxx ...)
2. Add mesh2sdf_triangle_gpu_fast_nopre function in wisp/csrc/external/mesh2sdf_kernel.cu which can **return both SDF and closest triangle**.
3. Implement closest_point function in wisp/ops/mesh/closest_point.py. closest points are calculated from closest triangles returned from mesh2sdf_triangle_gpu_fast_nopre function.

Tests:

Unfortunately, I'm not good at pytest code. I just tested the code by printing results on terminal.

Test process:

1. Add print() in closest_tex() function (wisp/ops/mesh/closest_tex.py) 
```python
import torch
import numpy as np
from .barycentric_coordinates import barycentric_coordinates
from .closest_point import closest_point
from .sample_tex import sample_tex

def closest_tex(
    V : torch.Tensor, 
    F : torch.Tensor,
    TV : torch.Tensor,
    TF : torch.Tensor,
    materials,
    points : torch.Tensor):
    """Returns the closest texture for a set of points.

        V (torch.FloatTensor): mesh vertices of shape [V, 3] 
        F (torch.LongTensor): mesh face indices of shape [F, 3]
        TV (torch.FloatTensor): 
        TF (torch.FloatTensor):
        materials:
        points (torch.FloatTensor): sample locations of shape [N, 3]

    Returns:
        (torch.FloatTensor): texture samples of shape [N, 3]
    """

    TV = TV.to(V.device)
    TF = TF.to(V.device)
    points = points.to(V.device)

    dist, hit_pts, hit_tidx = closest_point(V, F, points)

    ##### !!!test by printing!!! #####
    ######################### 
    print(dist)  # should be same with below result
    print(((hit_pts - points) ** 2).sum(dim=1).sqrt())  # distance between hit_pts and points should be same with dist
    ######################### 
    ######################### 

    hit_F = F[hit_tidx]
    hit_V = V[hit_F]
    BC = barycentric_coordinates(hit_pts.cuda(), hit_V[:,0], hit_V[:,1], hit_V[:,2])

    hit_TF = TF[hit_tidx]
    hit_TM = hit_TF[...,3]
    hit_TF = hit_TF[...,:3]

    if TV.shape[0] > 0:
        hit_TV = TV[hit_TF]
        hit_Tp = (hit_TV * BC.unsqueeze(-1)).sum(1)
    else:
        hit_Tp = BC
    
    rgb = sample_tex(hit_Tp, hit_TM, materials)

    return rgb, hit_pts, dist

```
2. Run following code
```
from wisp.datasets.formats import MeshSampledSDFDataset


dataset = MeshSampledSDFDataset(mesh_path="data/obj/mesh.obj", split="train", sample_mode=["trace"], num_samples=5000, sample_tex=True, mode_norm="sphere")
```

Results:

I also trained the SDF + texture model on some .obj files after implementing closest_point function. (However, I don't include training code on this PR)

First image is .obj model in blender and second image is the SDF + texture model result. (wrong eye coloring is due to wrong .obj texture data, so you can ignore it)

![Untitled (9)](https://github.com/NVIDIAGameWorks/kaolin-wisp/assets/98357201/f58e8554-6bf5-4a18-89e7-4ce71b2aa8ed)
![Untitled (10)](https://github.com/NVIDIAGameWorks/kaolin-wisp/assets/98357201/2bccf84e-19a6-470a-94d9-2f6ab24870f2)


