### PR TITLE
Bugfix/image training

### DIFF
--- a/wisp/models/grids/hash_grid.py
+++ b/wisp/models/grids/hash_grid.py
@@ -85,7 +85,6 @@ class HashGrid(BLASGrid):
         self.coord_dim = coord_dim
         self.codebook = MultiTable(resolutions, self.coord_dim, self.feature_dim, self.feature_std, self.codebook_size)
 
-    # TODO(Nasib): add the coord_dim argument
     @classmethod
     def from_octree(cls,
                     blas               : BaseAS,

--- a/wisp/models/grids/hash_grid.py
+++ b/wisp/models/grids/hash_grid.py
@@ -83,8 +83,10 @@ class HashGrid(BLASGrid):
         self.codebook_size = 2 ** self.codebook_bitwidth
 
         self.coord_dim = coord_dim
+        # TODO(nasib): codebook size is not max num of features. It is the max num of rows.
         self.codebook = MultiTable(resolutions, self.coord_dim, self.feature_dim, self.feature_std, self.codebook_size)
 
+    # TODO(Nasib): add the coord_dim argument
     @classmethod
     def from_octree(cls,
                     blas               : BaseAS,
@@ -130,7 +132,8 @@ class HashGrid(BLASGrid):
                        feature_bias       : float = 0.0,
                        codebook_bitwidth  : int   = 8,
                        min_grid_res       : int   = 16,
-                       max_grid_res       : int   = None) -> HashGrid:
+                       max_grid_res       : int   = None,
+                       coord_dim          : int   = 3) -> HashGrid:
         """
         Builds a hash grid using the geometric sequence initialization pattern from Muller et al. 2022 (Instant-NGP).
         This is an implementation of the geometric multiscale grid from
@@ -154,11 +157,14 @@ class HashGrid(BLASGrid):
             min_grid_res (int): min resolution of the feature grid.
             max_grid_res (int): max resolution of the feature grid.
         """
+        # TODO(nasib): Bug in geometric sequence initialization. min_res is off by 1.
         b = np.exp((np.log(max_grid_res) - np.log(min_grid_res)) / (num_lods-1))
+        # alternative: resolutions = [np.ceil(min_grid_res*(b**l)) for l in range(num_lods)]
         resolutions = [int(1 + np.floor(min_grid_res*(b**l))) for l in range(num_lods)]
         return cls(blas=blas, feature_dim=feature_dim, resolutions=resolutions, multiscale_type=multiscale_type,
-                   feature_std=feature_std, feature_bias=feature_bias, codebook_bitwidth=codebook_bitwidth)
+                   feature_std=feature_std, feature_bias=feature_bias, codebook_bitwidth=codebook_bitwidth, coord_dim=coord_dim)
 
+    # TODO(Nasib): add the coord_dim argument
     @classmethod
     def from_resolutions(cls,
                          blas: BaseAS,

--- a/wisp/models/grids/hash_grid.py
+++ b/wisp/models/grids/hash_grid.py
@@ -158,7 +158,7 @@ class HashGrid(BLASGrid):
             max_grid_res (int): max resolution of the feature grid.
         """
         b = np.exp((np.log(max_grid_res) - np.log(min_grid_res)) / (num_lods-1))
-        resolutions = [np.ceil(min_grid_res*(b**l)) for l in range(num_lods)]
+        resolutions = [int(np.floor(min_grid_res*(b**l))) for l in range(num_lods)]
         return cls(blas=blas, feature_dim=feature_dim, resolutions=resolutions, multiscale_type=multiscale_type,
                    feature_std=feature_std, feature_bias=feature_bias, codebook_bitwidth=codebook_bitwidth, coord_dim=coord_dim)
 

--- a/wisp/trainers/image_trainer.py
+++ b/wisp/trainers/image_trainer.py
@@ -101,6 +101,7 @@ class ImageTrainer(BaseTrainer):
             log.info("app_config not supplied to Tracker, config won't be logged in the pandas log")
             record_dict = {}
         
+        sha = None
         try:
             repo = git.Repo(search_parent_directories=True)
             sha = repo.head.object.hexsha[:8]

--- a/wisp/trainers/image_trainer.py
+++ b/wisp/trainers/image_trainer.py
@@ -164,7 +164,7 @@ class ImageTrainer(BaseTrainer):
         
         record_dict.update({"img_name" : img_name, "epoch": self.epoch, 
                             "log_fname" : self.tracker.log_fname, "model_fname": model_fname,
-                            "git_sha" : sha, "width": self.train_dataset.w, "height": self.train_dataset.h, 
+                            "git_sha" : sha if not sha is None else "", "width": self.train_dataset.w, "height": self.train_dataset.h, 
                             "num_pixels": self.train_dataset.w * self.train_dataset.h})
 
         record_dict.update(metrics_dict)


### PR DESCRIPTION
Some minor fixes in the image training pipeline. Coord_dim argument was not being passed to constructors and defaulted to 3 for 3 dimensions even in 2d case. Hash grid from geometric had a bug in the progression of the geometric sequence, resulting in the minimum resolution being off by one.