### PR TITLE
Reduce VRAM usage due to ray tensor generation by setting the tensors' dtype to torch.float32

### DIFF
--- a/wisp/datasets/formats/nerf_standard_dataset.py
+++ b/wisp/datasets/formats/nerf_standard_dataset.py
@@ -435,7 +435,7 @@ class NeRFSyntheticDataset(MultiviewDataset):
             masks = torch.ones_like(rgbs[... ,0:1]).bool()
         else:
             masks = (alpha > 0.5).bool()
-            rgbs = rgbs[...,:3] * alpha + (1-alpha) * np.array(self.bg_color).astype(np.float)
+            rgbs = rgbs[...,:3] * alpha + (1-alpha) * np.array(self.bg_color).astype(np.float32)
             rgbs = np.clip(rgbs, 0.0, 1.0)
 
         return {"rgb": rgbs, "masks": masks, "rays": rays, "cameras": cameras}

--- a/wisp/datasets/formats/nerf_standard_dataset.py
+++ b/wisp/datasets/formats/nerf_standard_dataset.py
@@ -419,7 +419,7 @@ class NeRFSyntheticDataset(MultiviewDataset):
                                       near=default_near,
                                       x0=x0,
                                       y0=y0,
-                                      dtype=torch.float64)
+                                      dtype=torch.float)
             camera.change_coordinate_system(blender_coords())
             cameras[basenames[i]] = camera
             ray_grid = generate_centered_pixel_coords(camera.width, camera.height,
@@ -427,7 +427,7 @@ class NeRFSyntheticDataset(MultiviewDataset):
             rays.append \
                 (generate_pinhole_rays(camera.to(ray_grid[0].device), ray_grid).reshape(camera.height, camera.width, 3))
 
-        rays = Rays.stack(rays).to(dtype=torch.float).to('cpu')
+        rays = Rays.stack(rays).to(device='cpu', dtype=torch.float)
 
         rgbs = imgs[... ,:3]
         alpha = imgs[... ,3:4]
@@ -435,7 +435,7 @@ class NeRFSyntheticDataset(MultiviewDataset):
             masks = torch.ones_like(rgbs[... ,0:1]).bool()
         else:
             masks = (alpha > 0.5).bool()
-            rgbs = rgbs[...,:3] * alpha + (1-alpha) * np.array(self.bg_color).astype(np.float32)
+            rgbs = rgbs[...,:3] * alpha + (1-alpha) * np.array(self.bg_color).astype(np.float)
             rgbs = np.clip(rgbs, 0.0, 1.0)
 
         return {"rgb": rgbs, "masks": masks, "rays": rays, "cameras": cameras}

--- a/wisp/datasets/formats/nerf_standard_dataset.py
+++ b/wisp/datasets/formats/nerf_standard_dataset.py
@@ -427,7 +427,7 @@ class NeRFSyntheticDataset(MultiviewDataset):
             rays.append \
                 (generate_pinhole_rays(camera.to(ray_grid[0].device), ray_grid).reshape(camera.height, camera.width, 3))
 
-        rays = Rays.stack(rays).to(device='cpu', dtype=torch.float)
+        rays = Rays.stack(rays).to(dtype=torch.float).to('cpu')
 
         rgbs = imgs[... ,:3]
         alpha = imgs[... ,3:4]

--- a/wisp/ops/raygen/raygen.py
+++ b/wisp/ops/raygen/raygen.py
@@ -15,8 +15,8 @@ from wisp.core import Rays
 # -- Supersample / Ray jitter --
 
 def generate_default_grid(width, height, device=None):
-    h_coords = torch.arange(height, device=device, dtype=torch.long)
-    w_coords = torch.arange(width, device=device, dtype=torch.long)
+    h_coords = torch.arange(height, device=device, dtype=torch.float)
+    w_coords = torch.arange(width, device=device, dtype=torch.float)
     return torch.meshgrid(h_coords, w_coords)  # return pixel_y, pixel_x
 
 


### PR DESCRIPTION
# Why
Dataset preparation required more than 12GB VRAM on the lego dataset when I tried to train a model with the preset `nerf_hash` config. 

# What
Ray tensors are generated as float64 tensors during the dataset preparation in `main` while they are converted to float32 just a few lines below. This PR changes `dtype` for the tensor generation to float32. This modification reduced VRAM usage (14GB-ish to 8GB-ish, but may vary) with the preset config. 

P.S. The RTMV dataset may need a similar change, but this PR does not include it because I could not work with the dataset due to its size.